### PR TITLE
feat: `getSessionTokens()`

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -1,4 +1,10 @@
-import { getUser, handleCallback, isSignedIn, signIn, signOut } from "./mod.ts";
+import {
+  getSessionTokens,
+  handleCallback,
+  isSignedIn,
+  signIn,
+  signOut,
+} from "./mod.ts";
 import { loadSync, serve, Status } from "./deps.ts";
 
 loadSync({ export: true });
@@ -16,9 +22,10 @@ async function handler(request: Request): Promise<Response> {
       <a href="/signin">Sign in</a>
     `;
     if (isSignedIn(request)) {
-      const user = await getUser(request, "github");
+      const tokens = await getSessionTokens(request);
       body = `
-        <p>Hello, ${user.login}!</p>
+        <p>Your tokens:<p>
+        <pre>${JSON.stringify(tokens, undefined, 2)}</pre>
         <a href="/signout">Sign out</a>
       `;
     }

--- a/mod.ts
+++ b/mod.ts
@@ -23,42 +23,34 @@ const TOKENS_BY_SITE_SESSION_KV_PREFIX = "tokens_by_site_session";
 
 const kv = await Deno.openKv();
 
-export interface Provider {
-  oauth2ClientConfig: OAuth2ClientConfig;
-  getUserUrl: string;
-}
+export type Provider = "github";
 
-function createGitHubProvider(): Provider {
+function createGitHubClient(): OAuth2ClientConfig {
   return {
-    oauth2ClientConfig: {
-      clientId: Deno.env.get("GITHUB_CLIENT_ID")!,
-      clientSecret: Deno.env.get("GITHUB_CLIENT_SECRET")!,
-      authorizationEndpointUri: "https://github.com/login/oauth/authorize",
-      tokenUri: "https://github.com/login/oauth/access_token",
-    },
-    getUserUrl: "https://api.github.com/user",
+    clientId: Deno.env.get("GITHUB_CLIENT_ID")!,
+    clientSecret: Deno.env.get("GITHUB_CLIENT_SECRET")!,
+    authorizationEndpointUri: "https://github.com/login/oauth/authorize",
+    tokenUri: "https://github.com/login/oauth/access_token",
   };
 }
 
-export type ProviderId = "github";
-
-export function createProvider(providerId: ProviderId) {
-  switch (providerId) {
+export function createClientConfig(provider: Provider): OAuth2ClientConfig {
+  switch (provider) {
     case "github":
-      return createGitHubProvider();
+      return createGitHubClient();
     default:
-      throw new Error(`Provider ID "${providerId}" not supported`);
+      throw new Error(`Provider ID "${provider}" not supported`);
   }
 }
 
 export async function signIn(
-  providerIdOrProvider: ProviderId | Provider,
+  providerOrClientConfig: Provider | OAuth2ClientConfig,
 ): Promise<Response> {
-  const provider = typeof providerIdOrProvider === "string"
-    ? createProvider(providerIdOrProvider)
-    : providerIdOrProvider;
+  const clientConfig = typeof providerOrClientConfig === "string"
+    ? createClientConfig(providerOrClientConfig)
+    : providerOrClientConfig;
 
-  const oauth2Client = new OAuth2Client(provider.oauth2ClientConfig);
+  const oauth2Client = new OAuth2Client(clientConfig);
 
   // Generate a random state
   const state = crypto.randomUUID();
@@ -86,12 +78,12 @@ export async function signIn(
 
 export async function handleCallback(
   request: Request,
-  providerIdOrProvider: ProviderId | Provider,
+  providerOrClientConfig: Provider | OAuth2ClientConfig,
   redirectUrl = "/",
 ): Promise<Response> {
-  const provider = typeof providerIdOrProvider === "string"
-    ? createProvider(providerIdOrProvider)
-    : providerIdOrProvider;
+  const clientConfig = typeof providerOrClientConfig === "string"
+    ? createClientConfig(providerOrClientConfig)
+    : providerOrClientConfig;
 
   // Get the OAuth session ID from the client's cookie and ensure it's defined
   const oauthSessionId = getCookies(request.headers)[OAUTH_SESSION_COOKIE_NAME];
@@ -109,7 +101,7 @@ export async function handleCallback(
   await kv.delete([OAUTH_SESSION_KV_PREFIX, oauthSessionId]);
 
   // Generate a random site session ID for the new user cookie
-  const oauth2Client = new OAuth2Client(provider.oauth2ClientConfig);
+  const oauth2Client = new OAuth2Client(clientConfig);
   const siteSessionId = crypto.randomUUID();
   const tokens = await oauth2Client.code.getToken(
     request.url,
@@ -143,14 +135,7 @@ export async function signOut(
   return new Response(null, { status: Status.Found, headers });
 }
 
-export async function getUser(
-  request: Request,
-  providerIdOrProvider: ProviderId | Provider,
-) {
-  const provider = typeof providerIdOrProvider === "string"
-    ? createProvider(providerIdOrProvider)
-    : providerIdOrProvider;
-
+export async function getSessionTokens(request: Request) {
   const siteSessionId = getCookies(request.headers)[SITE_SESSION_COOKIE_NAME];
   assert(siteSessionId, `Cookie ${SITE_SESSION_COOKIE_NAME} not found`);
 
@@ -160,11 +145,5 @@ export async function getUser(
   ]);
   const tokens = tokensRes.value;
   assert(tokens, `Tokens by site session ${siteSessionId} entry not found`);
-
-  const resp = await fetch(provider.getUserUrl, {
-    headers: { authorization: `Bearer ${tokens.accessToken}` },
-  });
-
-  if (!resp.ok) throw new Error(await resp.text());
-  return await resp.json();
+  return tokens;
 }

--- a/test.ts
+++ b/test.ts
@@ -1,38 +1,29 @@
-import {
-  createProvider,
-  isSignedIn,
-  type Provider,
-  signIn,
-  signOut,
-} from "./mod.ts";
+import { createClientConfig, isSignedIn, signIn, signOut } from "./mod.ts";
 import {
   assert,
   assertEquals,
   getSetCookies,
   isRedirectStatus,
   loadSync,
+  type OAuth2ClientConfig,
 } from "./deps.ts";
 
 loadSync({ export: true });
 
-Deno.test("createProvider()", () => {
+Deno.test("createClient()", () => {
   const clientId = Deno.env.get("GITHUB_CLIENT_ID")!;
   const clientSecret = Deno.env.get("GITHUB_CLIENT_SECRET")!;
 
-  assertEquals<Provider>(createProvider("github"), {
-    oauth2ClientConfig: {
-      clientId,
-      clientSecret,
-      authorizationEndpointUri: "https://github.com/login/oauth/authorize",
-      tokenUri: "https://github.com/login/oauth/access_token",
-    },
-    getUserUrl: "https://api.github.com/user",
+  assertEquals<OAuth2ClientConfig>(createClientConfig("github"), {
+    clientId,
+    clientSecret,
+    authorizationEndpointUri: "https://github.com/login/oauth/authorize",
+    tokenUri: "https://github.com/login/oauth/access_token",
   });
 });
 
 Deno.test("signIn()", async () => {
-  const provider = createProvider("github");
-  const response = await signIn(provider);
+  const response = await signIn("github");
 
   assert(isRedirectStatus(response.status));
   assertEquals(typeof response.headers.get("location"), "string");


### PR DESCRIPTION
This change:
1. Adds `getSessionTokens()`
2. Removes `getUser()`
3. Simplifies other parts of the API as a result.

Closes #33.