### PR TITLE
fix: sign out

### DIFF
--- a/src/sign_out.ts
+++ b/src/sign_out.ts
@@ -17,6 +17,6 @@ export async function signOut(request: Request, redirectUrl = "/") {
   await deleteTokensBySiteSession(siteSessionId);
 
   const response = redirect(redirectUrl);
-  deleteCookie(response.headers, cookieName);
+  deleteCookie(response.headers, cookieName, { path: "/" });
   return response;
 }

--- a/src/sign_out_test.ts
+++ b/src/sign_out_test.ts
@@ -48,7 +48,7 @@ Deno.test("signOut()", async (test) => {
     assertEquals(response.status, Status.Found);
     assertEquals(
       response.headers.get("set-cookie"),
-      `${SITE_COOKIE_NAME}=; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+      `${SITE_COOKIE_NAME}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
     );
 
     // Cleanup


### PR DESCRIPTION
You need to set the path to the top level path (cookies are really hard, trust me, I know), otherwise sign out will not work for nested paths (i.e. `/api/logout`). 

Here's a test you can do to see the difference of behavior. The `/api/logout` doesn't work at all here. Replace the `deno_kv_oauth` import with this branch to see the fix.

```ts
// deno run --unstable --allow-env --allow-net demo.ts
import {
  createClient,
  getSessionTokens,
  handleCallback,
  isSignedIn,
  signIn,
  signOut,
} from "https://deno.land/x/deno_kv_oauth/mod.ts";
import { serve, Status } from "https://deno.land/std/http/mod.ts";
import "https://deno.land/std/dotenv/load.ts";

const client = createClient("github");

async function indexHandler(request: Request) {
  let body = `
    <p>Who are you?</p>
    <p><a href="/api/login">Sign in with GitHub</a></p>
  `;
  if (isSignedIn(request)) {
    const tokens = await getSessionTokens(request);
    body = `
      <p>Your tokens:<p>
      <pre>${JSON.stringify(tokens, undefined, 2)}</pre>
      <a href="/api/logout">Sign out</a>
    `;
  }
  return new Response(body, {
    headers: { "content-type": "text/html; charset=utf-8" },
  });
}

async function handler(request: Request): Promise<Response> {
  if (request.method !== "GET") {
    return new Response(null, { status: Status.NotFound });
  }

  const { pathname } = new URL(request.url);
  switch (pathname) {
    case "/": {
      return await indexHandler(request);
    }
    case "/api/login": {
      return await signIn(request, client);
    }
    case "/api/callback": {
      return await handleCallback(request, client);
    }
    case "/api/logout": {
      return await signOut(request);
    }
    default: {
      return new Response(null, { status: Status.NotFound });
    }
  }
}

serve(handler);
```