### PR TITLE
feat: add `getSessionId()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Minimal OAuth powered by Deno KV.
 // deno run --unstable --allow-env --allow-net demo.ts
 import {
   createClient,
+  getSessionId,
   getSessionTokens,
   handleCallback,
-  isSignedIn,
   signIn,
   signOut,
 } from "https://deno.land/x/deno_kv_oauth/mod.ts";
@@ -30,8 +30,9 @@ async function indexHandler(request: Request) {
     <p>Who are you?</p>
     <p><a href="/signin">Sign in with GitHub</a></p>
   `;
-  if (isSignedIn(request)) {
-    const tokens = await getSessionTokens(request);
+  const sessionId = getSessionId(request);
+  if (sessionId !== null) {
+    const tokens = await getSessionTokens(sessionId);
     body = `
       <p>Your tokens:<p>
       <pre>${JSON.stringify(tokens, undefined, 2)}</pre>

--- a/demo.ts
+++ b/demo.ts
@@ -1,9 +1,9 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import {
   createClient,
+  getSessionId,
   getSessionTokens,
   handleCallback,
-  isSignedIn,
   signIn,
   signOut,
 } from "./mod.ts";
@@ -18,8 +18,9 @@ async function indexHandler(request: Request) {
     <p>Who are you?</p>
     <p><a href="/signin">Sign in with GitHub</a></p>
   `;
-  if (isSignedIn(request)) {
-    const tokens = await getSessionTokens(request);
+  const sessionId = getSessionId(request);
+  if (sessionId !== null) {
+    const tokens = await getSessionTokens(sessionId);
     body = `
       <p>Your tokens:<p>
       <pre>${JSON.stringify(tokens, undefined, 2)}</pre>

--- a/mod.ts
+++ b/mod.ts
@@ -2,6 +2,6 @@
 export * from "./src/create_client.ts";
 export * from "./src/get_session_tokens.ts";
 export * from "./src/handle_callback.ts";
-export * from "./src/is_signed_in.ts";
+export * from "./src/get_session_id.ts";
 export * from "./src/sign_in.ts";
 export * from "./src/sign_out.ts";

--- a/src/get_session_id.ts
+++ b/src/get_session_id.ts
@@ -2,7 +2,7 @@
 import { getCookies } from "../deps.ts";
 import { getCookieName, isSecure, SITE_COOKIE_NAME } from "./_core.ts";
 
-export function isSignedIn(request: Request) {
+export function getSessionId(request: Request) {
   const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
-  return Boolean(getCookies(request.headers)[cookieName]);
+  return getCookies(request.headers)[cookieName] ?? null;
 }

--- a/src/get_session_id_test.ts
+++ b/src/get_session_id_test.ts
@@ -1,24 +1,24 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "../deps.ts";
+import { assertEquals, assertNotEquals } from "../deps.ts";
 import { SITE_COOKIE_NAME } from "./_core.ts";
-import { isSignedIn } from "./is_signed_in.ts";
+import { getSessionId } from "./get_session_id.ts";
 
-Deno.test("isSignedIn()", () => {
+Deno.test("getSessionId()", () => {
   const insecureRequest = new Request("http://example.com");
-  assertEquals(isSignedIn(insecureRequest), false);
+  assertEquals(getSessionId(insecureRequest), null);
 
   insecureRequest.headers.set("cookie", "not-site-session=xxx");
-  assertEquals(isSignedIn(insecureRequest), false);
+  assertEquals(getSessionId(insecureRequest), null);
 
   insecureRequest.headers.set("cookie", `${SITE_COOKIE_NAME}=xxx`);
-  assertEquals(isSignedIn(insecureRequest), true);
+  assertNotEquals(getSessionId(insecureRequest), null);
 
   const secureRequest = new Request("https://example.com");
-  assertEquals(isSignedIn(secureRequest), false);
+  assertEquals(getSessionId(secureRequest), null);
 
   secureRequest.headers.set("cookie", "not-site-session=xxx");
-  assertEquals(isSignedIn(secureRequest), false);
+  assertEquals(getSessionId(secureRequest), null);
 
   secureRequest.headers.set("cookie", `__Host-${SITE_COOKIE_NAME}=xxx`);
-  assertEquals(isSignedIn(secureRequest), true);
+  assertNotEquals(getSessionId(secureRequest), null);
 });

--- a/src/get_session_tokens.ts
+++ b/src/get_session_tokens.ts
@@ -1,15 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { getCookies } from "../deps.ts";
-import {
-  getCookieName,
-  getTokensBySiteSession,
-  isSecure,
-  SITE_COOKIE_NAME,
-} from "./_core.ts";
+import { getTokensBySiteSession } from "./_core.ts";
 
-export async function getSessionTokens(request: Request) {
-  const siteCookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
-  const siteSessionId = getCookies(request.headers)[siteCookieName];
-
-  return siteSessionId ? await getTokensBySiteSession(siteSessionId) : null;
+export async function getSessionTokens(sessionId: string) {
+  return await getTokensBySiteSession(sessionId);
 }

--- a/src/get_session_tokens_test.ts
+++ b/src/get_session_tokens_test.ts
@@ -1,58 +1,18 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, type Tokens } from "../deps.ts";
 import { getSessionTokens } from "./get_session_tokens.ts";
-import {
-  deleteTokensBySiteSession,
-  setTokensBySiteSession,
-  SITE_COOKIE_NAME,
-} from "./_core.ts";
+import { deleteTokensBySiteSession, setTokensBySiteSession } from "./_core.ts";
 
-Deno.test("getSessionTokens()", async (test) => {
-  await test.step("signed out with insecure origin", async () => {
-    const request = new Request("http://example.com");
-    assertEquals(await getSessionTokens(request), null);
-  });
+Deno.test("getSessionTokens()", async () => {
+  const sessionId = crypto.randomUUID();
+  const tokens: Tokens = {
+    accessToken: crypto.randomUUID(),
+    tokenType: crypto.randomUUID(),
+  };
+  await setTokensBySiteSession(sessionId, tokens);
 
-  await test.step("signed out with insecure origin", async () => {
-    const request = new Request("https://example.com");
-    assertEquals(await getSessionTokens(request), null);
-  });
+  assertEquals(await getSessionTokens(sessionId), tokens);
 
-  await test.step("signed in with insecure origin", async () => {
-    const siteSessionId = crypto.randomUUID();
-    const tokens: Tokens = {
-      accessToken: crypto.randomUUID(),
-      tokenType: crypto.randomUUID(),
-    };
-    await setTokensBySiteSession(siteSessionId, tokens);
-    const request = new Request("http://example.com", {
-      headers: {
-        cookie: `${SITE_COOKIE_NAME}=${siteSessionId}`,
-      },
-    });
-
-    assertEquals(await getSessionTokens(request), tokens);
-
-    // Cleanup
-    await deleteTokensBySiteSession(siteSessionId);
-  });
-
-  await test.step("signed in with secure origin", async () => {
-    const siteSessionId = crypto.randomUUID();
-    const tokens: Tokens = {
-      accessToken: crypto.randomUUID(),
-      tokenType: crypto.randomUUID(),
-    };
-    await setTokensBySiteSession(siteSessionId, tokens);
-    const request = new Request("https://example.com", {
-      headers: {
-        cookie: `__Host-${SITE_COOKIE_NAME}=${siteSessionId}`,
-      },
-    });
-
-    assertEquals(await getSessionTokens(request), tokens);
-
-    // Cleanup
-    await deleteTokensBySiteSession(siteSessionId);
-  });
+  // Cleanup
+  await deleteTokensBySiteSession(sessionId);
 });

--- a/src/handle_callback.ts
+++ b/src/handle_callback.ts
@@ -33,12 +33,12 @@ export async function handleCallback(
   await deleteOAuthSession(oauthSessionId);
 
   // Generate a random site session ID for the new user cookie
-  const siteSessionId = crypto.randomUUID();
+  const sessionId = crypto.randomUUID();
   const tokens = await oauth2Client.code.getToken(
     request.url,
     oauthSession,
   );
-  await setTokensBySiteSession(siteSessionId, tokens);
+  await setTokensBySiteSession(sessionId, tokens);
 
   const response = redirect(redirectUrl);
   setCookie(
@@ -46,7 +46,7 @@ export async function handleCallback(
     {
       ...COOKIE_BASE,
       name: getCookieName(SITE_COOKIE_NAME, isSecure(request.url)),
-      value: siteSessionId,
+      value: sessionId,
       secure: isSecure(request.url),
     },
   );

--- a/src/sign_out.ts
+++ b/src/sign_out.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { deleteCookie, getCookies } from "../deps.ts";
+import { deleteCookie } from "../deps.ts";
 import {
   deleteTokensBySiteSession,
   getCookieName,
@@ -7,16 +7,16 @@ import {
   redirect,
   SITE_COOKIE_NAME,
 } from "./_core.ts";
-import { isSignedIn } from "./is_signed_in.ts";
+import { getSessionId } from "./get_session_id.ts";
 
 export async function signOut(request: Request, redirectUrl = "/") {
-  if (!isSignedIn(request)) return redirect(redirectUrl);
+  const sessionId = getSessionId(request);
+  if (sessionId === null) return redirect(redirectUrl);
 
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
-  const siteSessionId = getCookies(request.headers)[cookieName];
-  await deleteTokensBySiteSession(siteSessionId);
+  await deleteTokensBySiteSession(sessionId);
 
   const response = redirect(redirectUrl);
+  const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
   deleteCookie(response.headers, cookieName, { path: "/" });
   return response;
 }

--- a/src/sign_out_test.ts
+++ b/src/sign_out_test.ts
@@ -29,21 +29,21 @@ Deno.test("signOut()", async (test) => {
   });
 
   await test.step("signed in with insecure origin", async () => {
-    const siteSessionId = crypto.randomUUID();
+    const sessionId = crypto.randomUUID();
     const tokens: Tokens = {
       accessToken: crypto.randomUUID(),
       tokenType: crypto.randomUUID(),
     };
-    await setTokensBySiteSession(siteSessionId, tokens);
+    await setTokensBySiteSession(sessionId, tokens);
     const request = new Request("http://example.com", {
       headers: {
-        cookie: `${SITE_COOKIE_NAME}=${siteSessionId}`,
+        cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
       },
     });
     const redirectUrl = "/why-hello-there";
     const response = await signOut(request, redirectUrl);
 
-    assertEquals(await getTokensBySiteSession(siteSessionId), null);
+    assertEquals(await getTokensBySiteSession(sessionId), null);
     assertEquals(response.headers.get("location"), redirectUrl);
     assertEquals(response.status, Status.Found);
     assertEquals(
@@ -52,25 +52,25 @@ Deno.test("signOut()", async (test) => {
     );
 
     // Cleanup
-    deleteTokensBySiteSession(siteSessionId);
+    deleteTokensBySiteSession(sessionId);
   });
 
   await test.step("signed in with secure origin", async () => {
-    const siteSessionId = crypto.randomUUID();
+    const sessionId = crypto.randomUUID();
     const tokens: Tokens = {
       accessToken: crypto.randomUUID(),
       tokenType: crypto.randomUUID(),
     };
-    await setTokensBySiteSession(siteSessionId, tokens);
+    await setTokensBySiteSession(sessionId, tokens);
     const request = new Request("https://example.com", {
       headers: {
-        cookie: `__Host-${SITE_COOKIE_NAME}=${siteSessionId}`,
+        cookie: `__Host-${SITE_COOKIE_NAME}=${sessionId}`,
       },
     });
     const redirectUrl = "/why-hello-there";
     const response = await signOut(request, redirectUrl);
 
-    assertEquals(await getTokensBySiteSession(siteSessionId), null);
+    assertEquals(await getTokensBySiteSession(sessionId), null);
     assertEquals(response.headers.get("location"), redirectUrl);
     assertEquals(response.status, Status.Found);
     assertEquals(
@@ -79,6 +79,6 @@ Deno.test("signOut()", async (test) => {
     );
 
     // Cleanup
-    deleteTokensBySiteSession(siteSessionId);
+    deleteTokensBySiteSession(sessionId);
   });
 });


### PR DESCRIPTION
This change:
- Adds `getSessionId(request: Request): string | null`, which is more versatile than `isSignedIn()`. This will also help projects that currently implement OAuth transition.
- Removes `isSignedIn()`, as `getSessionId()` can be used in the same capacity by checking if truthy.
- Replaces instances of `siteSessionId` with just `sessionId`.
- Simplifies `getSessionTokens()` to accept `sessionId: string`.