### PR TITLE
refactor: `handleCallback()` returns `response`, `tokens` and `sessionId`

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -46,7 +46,8 @@ async function handler(request: Request): Promise<Response> {
       return await signIn(request, client);
     }
     case "/callback": {
-      return await handleCallback(request, client);
+      const { response } = await handleCallback(request, client);
+      return response;
     }
     case "/signout": {
       return await signOut(request);

--- a/src/handle_callback.ts
+++ b/src/handle_callback.ts
@@ -16,7 +16,7 @@ export async function handleCallback(
   request: Request,
   oauth2Client: OAuth2Client,
   redirectUrl = "/",
-): Promise<Response> {
+) {
   // Get the OAuth session ID from the client's cookie and ensure it's defined
   const oauthCookieName = getCookieName(
     OAUTH_COOKIE_NAME,
@@ -50,5 +50,9 @@ export async function handleCallback(
       secure: isSecure(request.url),
     },
   );
-  return response;
+  return {
+    response,
+    sessionId,
+    tokens,
+  };
 }


### PR DESCRIPTION
Usually, some setup is performed within the callback handler. This helps with that.