### PR TITLE
chore: add `handleCallback()` tests

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -3,6 +3,7 @@ export {
   assert,
   assertEquals,
   assertNotEquals,
+  assertRejects,
   assertThrows,
 } from "https://deno.land/std@0.190.0/testing/asserts.ts";
 export {

--- a/src/handle_callback.ts
+++ b/src/handle_callback.ts
@@ -33,6 +33,7 @@ export async function handleCallback(
   await deleteOAuthSession(oauthSessionId);
 
   // Generate a random site session ID for the new user cookie
+  // This is as far as automated testing can go
   const sessionId = crypto.randomUUID();
   const tokens = await oauth2Client.code.getToken(
     request.url,

--- a/src/handle_callback_test.ts
+++ b/src/handle_callback_test.ts
@@ -1,0 +1,45 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import { handleCallback } from "./handle_callback.ts";
+import { assertRejects, OAuth2Client } from "../deps.ts";
+import {
+  OAUTH_COOKIE_NAME,
+  type OAuthSession,
+  setOAuthSession,
+} from "./_core.ts";
+
+Deno.test("handleCallback()", async (test) => {
+  const client = new OAuth2Client({
+    clientId: crypto.randomUUID(),
+    clientSecret: crypto.randomUUID(),
+    authorizationEndpointUri: "https://example.com/authorize",
+    tokenUri: "https://example.com/token",
+  });
+
+  await test.step("no oauth cookie", async () => {
+    const request = new Request("http://example.com");
+    await assertRejects(() => handleCallback(request, client));
+  });
+
+  await test.step("oauth cookie with invalid value", async () => {
+    const request = new Request("http://example.com", {
+      headers: { cookie: `${OAUTH_COOKIE_NAME}=xxx` },
+    });
+    await assertRejects(() => handleCallback(request, client));
+  });
+
+  await test.step("rejects at furthest point", async () => {
+    const oauthSessionId = crypto.randomUUID();
+    const oauthSession: OAuthSession = {
+      state: crypto.randomUUID(),
+      codeVerifier: crypto.randomUUID(),
+    };
+    await setOAuthSession(oauthSessionId, oauthSession);
+    const request = new Request(
+      "http://example.com/callback?code=xxx&state=xxx",
+      {
+        headers: { cookie: `${OAUTH_COOKIE_NAME}=${oauthSessionId}` },
+      },
+    );
+    await assertRejects(async () => await handleCallback(request, client));
+  });
+});

--- a/src/handle_callback_test.ts
+++ b/src/handle_callback_test.ts
@@ -2,10 +2,12 @@
 import { handleCallback } from "./handle_callback.ts";
 import { assertRejects, OAuth2Client } from "../deps.ts";
 import {
+  getOAuthSession,
   OAUTH_COOKIE_NAME,
   type OAuthSession,
   setOAuthSession,
 } from "./_core.ts";
+import { assertEquals } from "https://deno.land/std@0.190.0/testing/asserts.ts";
 
 Deno.test("handleCallback()", async (test) => {
   const client = new OAuth2Client({
@@ -20,7 +22,7 @@ Deno.test("handleCallback()", async (test) => {
     await assertRejects(() => handleCallback(request, client));
   });
 
-  await test.step("oauth cookie with invalid value", async () => {
+  await test.step("no oauth session", async () => {
     const request = new Request("http://example.com", {
       headers: { cookie: `${OAUTH_COOKIE_NAME}=xxx` },
     });
@@ -41,5 +43,6 @@ Deno.test("handleCallback()", async (test) => {
       },
     );
     await assertRejects(async () => await handleCallback(request, client));
+    assertEquals(await getOAuthSession(oauthSessionId), null);
   });
 });


### PR DESCRIPTION
Unfortunately, 100% coverage is not possible.