### PR TITLE
feat: slack client

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ following providers (and their provider IDs):
 1. GitHub (`github`)
 1. GitLab (`gitlab`)
 1. Google (`google`)
+1. Slack (`slack`)
 
 > If there's a pre-configured OAuth2 client for a provider you'd like added,
 > please submit a pull request or

--- a/src/create_client.ts
+++ b/src/create_client.ts
@@ -82,7 +82,7 @@ function createGitLabClientConfig(
 }
 
 /**
- * @see {@link https://api.slack.com/legacy/oauth}
+ * @see {@link https://api.slack.com/authentication/oauth-v2}
  * @todo Define required config via types instead of assertions.
  */
 function createSlackClientConfig(
@@ -96,8 +96,8 @@ function createSlackClientConfig(
     ...moreOAuth2ClientConfig,
     clientId: Deno.env.get("SLACK_CLIENT_ID")!,
     clientSecret: Deno.env.get("SLACK_CLIENT_SECRET")!,
-    authorizationEndpointUri: "https://slack.com/oauth/authorize",
-    tokenUri: "https://slack.com/api/oauth.access",
+    authorizationEndpointUri: "https://slack.com/oauth/v2/authorize",
+    tokenUri: "https://slack.com/api/oauth.v2.access",
   };
 }
 

--- a/src/create_client.ts
+++ b/src/create_client.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { assert, OAuth2Client, OAuth2ClientConfig } from "../deps.ts";
 
-export type Provider = "discord" | "github" | "gitlab" | "google";
+export type Provider = "discord" | "github" | "gitlab" | "google" | "slack";
 
 /**
  * @see {@link https://discord.com/developers/docs/topics/oauth2}
@@ -81,6 +81,26 @@ function createGitLabClientConfig(
   };
 }
 
+/**
+ * @see {@link https://api.slack.com/legacy/oauth}
+ * @todo Define required config via types instead of assertions.
+ */
+function createSlackClientConfig(
+  moreOAuth2ClientConfig?: Partial<OAuth2ClientConfig>,
+): OAuth2ClientConfig {
+  assert(
+    moreOAuth2ClientConfig?.defaults?.scope,
+    "`defaults.scope` must be defined",
+  );
+  return {
+    ...moreOAuth2ClientConfig,
+    clientId: Deno.env.get("SLACK_CLIENT_ID")!,
+    clientSecret: Deno.env.get("SLACK_CLIENT_SECRET")!,
+    authorizationEndpointUri: "https://slack.com/oauth/authorize",
+    tokenUri: "https://slack.com/api/oauth.access",
+  };
+}
+
 export function createClient(
   provider: Provider,
   moreOAuth2ClientConfig?: Partial<OAuth2ClientConfig>,
@@ -96,6 +116,8 @@ export function createClient(
       return new OAuth2Client(createGitLabClientConfig(moreOAuth2ClientConfig));
     case "google":
       return new OAuth2Client(createGoogleClientConfig(moreOAuth2ClientConfig));
+    case "slack":
+      return new OAuth2Client(createSlackClientConfig(moreOAuth2ClientConfig));
     default:
       throw new Error(`Provider ID "${provider}" not supported`);
   }

--- a/src/create_client_test.ts
+++ b/src/create_client_test.ts
@@ -107,4 +107,20 @@ Deno.test("createClient()", async (test) => {
     assertEquals(client.config.redirectUri, redirectUri);
     assertEquals(client.config.defaults, defaults);
   });
+
+  await test.step("slack", () => {
+    assertThrows(() => createClient("slack"));
+
+    const clientId = crypto.randomUUID();
+    const clientSecret = crypto.randomUUID();
+    const defaults = { scope: "scope" };
+
+    Deno.env.set("SLACK_CLIENT_ID", clientId);
+    Deno.env.set("SLACK_CLIENT_SECRET", clientSecret);
+
+    const client = createClient("slack", { defaults });
+    assertEquals(client.config.clientId, clientId);
+    assertEquals(client.config.clientSecret, clientSecret);
+    assertEquals(client.config.defaults, defaults);
+  });
 });


### PR DESCRIPTION
~~This is a "classic" slack app instead of a "new" slack app, but "new" slack apps aren't really oauth so probably out-of-scope for this module.~~

We decided to go with the "new" slack oauth option for now. Please make some noise if you need the old one for some reason.