### PR TITLE
feat: `getSessionId()` checks KV

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -18,7 +18,7 @@ const client = createClient("twitter", {
 });
 
 async function indexHandler(request: Request) {
-  const sessionId = getSessionId(request);
+  const sessionId = await getSessionId(request);
   const accessToken = sessionId !== null
     ? await getSessionAccessToken(client, sessionId)
     : "undefined";

--- a/src/get_session_id.ts
+++ b/src/get_session_id.ts
@@ -12,5 +12,9 @@ export async function getSessionId(request: Request) {
   const sessionId = getCookies(request.headers)[cookieName];
   if (sessionId === undefined) return null;
 
+  /**
+   * @todo Perhaps an eventual consistency check should happen first.
+   * Revisit this once more documentation about eventual consistency is published.
+   */
   return await getTokensBySiteSession(sessionId) !== null ? sessionId : null;
 }

--- a/src/get_session_id.ts
+++ b/src/get_session_id.ts
@@ -1,8 +1,16 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { getCookies } from "../deps.ts";
-import { getCookieName, isSecure, SITE_COOKIE_NAME } from "./_core.ts";
+import {
+  getCookieName,
+  getTokensBySiteSession,
+  isSecure,
+  SITE_COOKIE_NAME,
+} from "./_core.ts";
 
-export function getSessionId(request: Request) {
+export async function getSessionId(request: Request) {
   const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
-  return getCookies(request.headers)[cookieName] ?? null;
+  const sessionId = getCookies(request.headers)[cookieName];
+  if (sessionId === undefined) return null;
+
+  return await getTokensBySiteSession(sessionId) !== null ? sessionId : null;
 }

--- a/src/get_session_id_test.ts
+++ b/src/get_session_id_test.ts
@@ -1,24 +1,24 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertNotEquals } from "../deps.ts";
+import { assertEquals } from "../deps.ts";
 import { SITE_COOKIE_NAME } from "./_core.ts";
 import { getSessionId } from "./get_session_id.ts";
 
-Deno.test("getSessionId()", () => {
+Deno.test("await getSessionId()", async () => {
   const insecureRequest = new Request("http://example.com");
-  assertEquals(getSessionId(insecureRequest), null);
+  assertEquals(await getSessionId(insecureRequest), null);
 
   insecureRequest.headers.set("cookie", "not-site-session=xxx");
-  assertEquals(getSessionId(insecureRequest), null);
+  assertEquals(await getSessionId(insecureRequest), null);
 
   insecureRequest.headers.set("cookie", `${SITE_COOKIE_NAME}=xxx`);
-  assertNotEquals(getSessionId(insecureRequest), null);
+  assertEquals(await getSessionId(insecureRequest), null);
 
   const secureRequest = new Request("https://example.com");
-  assertEquals(getSessionId(secureRequest), null);
+  assertEquals(await getSessionId(secureRequest), null);
 
   secureRequest.headers.set("cookie", "not-site-session=xxx");
-  assertEquals(getSessionId(secureRequest), null);
+  assertEquals(await getSessionId(secureRequest), null);
 
   secureRequest.headers.set("cookie", `__Host-${SITE_COOKIE_NAME}=xxx`);
-  assertNotEquals(getSessionId(secureRequest), null);
+  assertEquals(await getSessionId(secureRequest), null);
 });

--- a/src/sign_out.ts
+++ b/src/sign_out.ts
@@ -10,7 +10,7 @@ import {
 import { getSessionId } from "./get_session_id.ts";
 
 export async function signOut(request: Request, redirectUrl = "/") {
-  const sessionId = getSessionId(request);
+  const sessionId = await getSessionId(request);
   if (sessionId === null) return redirect(redirectUrl);
 
   await deleteStoredTokensBySiteSession(sessionId);


### PR DESCRIPTION
This change adds a KV check into `getSessionId()` that ensures a token exists for a given `sessionId`.