### PR TITLE
perf: split runtime and dev dependencies

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,12 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export {
-  assert,
-  assertEquals,
-  assertNotEquals,
-  assertRejects,
-  assertThrows,
-} from "https://deno.land/std@0.191.0/testing/asserts.ts";
-export {
   isRedirectStatus,
   type RedirectStatus,
   Status,
@@ -23,6 +16,4 @@ export {
   type OAuth2ClientConfig,
   type Tokens,
 } from "https://deno.land/x/oauth2_client@v1.0.0/mod.ts";
-export { walk } from "https://deno.land/std@0.191.0/fs/walk.ts";
-export { globToRegExp } from "https://deno.land/std@0.191.0/path/glob.ts";
 export { SECOND } from "https://deno.land/std@0.191.0/datetime/constants.ts";

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,0 +1,11 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+export {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertThrows,
+} from "https://deno.land/std@0.191.0/testing/asserts.ts";
+export { walk } from "https://deno.land/std@0.191.0/fs/walk.ts";
+export { globToRegExp } from "https://deno.land/std@0.191.0/path/glob.ts";
+export * from "./deps.ts";

--- a/src/_core.ts
+++ b/src/_core.ts
@@ -107,3 +107,9 @@ export function redirect(location: string) {
     status: Status.Found,
   });
 }
+
+export function assert(cond: unknown, message: string) {
+  if (!cond) {
+    throw new Error(message);
+  }
+}

--- a/src/_core.ts
+++ b/src/_core.ts
@@ -108,7 +108,7 @@ export function redirect(location: string) {
   });
 }
 
-export function assert(cond: unknown, message: string) {
+export function assert(cond: unknown, message: string): asserts cond {
   if (!cond) {
     throw new Error(message);
   }

--- a/src/_core_test.ts
+++ b/src/_core_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, Status, type Tokens } from "../deps.ts";
+import { assert, assertEquals, Status, type Tokens } from "../dev_deps.ts";
 import {
   deleteOAuthSession,
   deleteStoredTokensBySiteSession,

--- a/src/create_client.ts
+++ b/src/create_client.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assert, OAuth2Client, OAuth2ClientConfig } from "../deps.ts";
+import { OAuth2Client, OAuth2ClientConfig } from "../deps.ts";
+import { assert } from "./_core.ts";
 
 export type Provider =
   | "discord"

--- a/src/create_client_test.ts
+++ b/src/create_client_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertThrows } from "../deps.ts";
+import { assertEquals, assertThrows } from "../dev_deps.ts";
 import { createClient } from "./create_client.ts";
 
 Deno.test("createClient()", async (test) => {

--- a/src/get_session_access_token_test.ts
+++ b/src/get_session_access_token_test.ts
@@ -1,10 +1,12 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { getSessionAccessToken } from "./get_session_access_token.ts";
-import { OAuth2Client, SECOND, Tokens } from "../deps.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+  OAuth2Client,
+  SECOND,
+  Tokens,
+} from "../dev_deps.ts";
 import { setTokensBySiteSession } from "./_core.ts";
 
 Deno.test("getSessionAccessToken()", async () => {

--- a/src/get_session_id_test.ts
+++ b/src/get_session_id_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "../deps.ts";
+import { assertEquals } from "../dev_deps.ts";
 import { SITE_COOKIE_NAME } from "./_core.ts";
 import { getSessionId } from "./get_session_id.ts";
 

--- a/src/handle_callback.ts
+++ b/src/handle_callback.ts
@@ -38,7 +38,7 @@ export async function handleCallback(
   const sessionId = crypto.randomUUID();
   const tokens = await oauth2Client.code.getToken(
     request.url,
-    oauthSession ?? undefined,
+    oauthSession,
   );
   await setTokensBySiteSession(sessionId, tokens);
 

--- a/src/handle_callback.ts
+++ b/src/handle_callback.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assert, getCookies, type OAuth2Client, setCookie } from "../deps.ts";
+import { getCookies, type OAuth2Client, setCookie } from "../deps.ts";
 import {
+  assert,
   COOKIE_BASE,
   deleteOAuthSession,
   getCookieName,
@@ -37,7 +38,7 @@ export async function handleCallback(
   const sessionId = crypto.randomUUID();
   const tokens = await oauth2Client.code.getToken(
     request.url,
-    oauthSession,
+    oauthSession ?? undefined,
   );
   await setTokensBySiteSession(sessionId, tokens);
 

--- a/src/handle_callback_test.ts
+++ b/src/handle_callback_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { handleCallback } from "./handle_callback.ts";
-import { assertRejects, OAuth2Client } from "../deps.ts";
+import { assertRejects, OAuth2Client } from "../dev_deps.ts";
 import {
   getOAuthSession,
   OAUTH_COOKIE_NAME,

--- a/src/sign_in_test.ts
+++ b/src/sign_in_test.ts
@@ -6,7 +6,7 @@ import {
   getSetCookies,
   OAuth2Client,
   Status,
-} from "../deps.ts";
+} from "../dev_deps.ts";
 import {
   deleteOAuthSession,
   getOAuthSession,

--- a/src/sign_out_test.ts
+++ b/src/sign_out_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, Status, type Tokens } from "../deps.ts";
+import { assertEquals, Status, type Tokens } from "../dev_deps.ts";
 import { signOut } from "./sign_out.ts";
 import {
   deleteStoredTokensBySiteSession,

--- a/tools/check_license.ts
+++ b/tools/check_license.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 // Copied from std/_tools/check_license.ts
 
-import { globToRegExp, walk } from "../deps.ts";
+import { globToRegExp, walk } from "../dev_deps.ts";
 
 const EXTENSIONS = [".ts"];
 const EXCLUDED_DIRS = ["cov"];


### PR DESCRIPTION
This PR splits external dependencies to 2 files, `deps.ts` and `dev_deps.ts`. Now the runtime code only depends on `deps.ts`. This prevents unnecesary modules (ex. `std/testing`, `std/path`, `std/fs`) exported to the users' module.