### PR TITLE
fix: gracefully shutdown KV before end of program

### DIFF
--- a/src/_core.ts
+++ b/src/_core.ts
@@ -24,6 +24,11 @@ export const COOKIE_BASE = {
 
 const kv = await Deno.openKv();
 
+// For graceful shutdown after tests.
+addEventListener("beforeunload", async () => {
+  await kv.close();
+});
+
 // OAuth session
 export interface OAuthSession {
   state: string;


### PR DESCRIPTION
For context, see https://deno.com/manual@v1.34.2/runtime/program_lifecycle#beforeunload-example.