### PR TITLE
feat: `KV_PATH` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ const client = new OAuth2Client({
 });
 ```
 
+### `KV_PATH` Environment Variable
+
+Optionally, you can define the path that KV uses by using the
+`--allow-env[=KV_PATH]` flag and setting the `KV_PATH` environment variable.
+E.g.
+
+```
+KV_PATH=:memory: deno run --allow-write --allow-read --allow-env=KV_PATH --unstable script.ts
+```
+
 ## Contributing
 
 Before submitting a pull request, please run `deno task ok` and ensure all

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
     "check:license": "deno run -A tools/check_license.ts --check",
     "check:types": "deno check --unstable demo.ts mod.ts",
     "check": "deno task check:license && deno task check:types",
-    "test": "deno test -A --unstable --allow-env --allow-read --parallel --doc --coverage=./cov",
+    "test": "KV_PATH=:memory: deno test -A --unstable --allow-env --allow-read --parallel --doc --coverage=./cov",
     "ok": "deno fmt --check && deno lint && deno task check && deno task test",
     "cov": "deno coverage ./cov/ --lcov --exclude='test.ts|testdata' > cov.lcov",
     "update": "deno run -A https://deno.land/x/udd/main.ts --test=\"deno task test\" deps.ts demo.ts"

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
     "check:license": "deno run -A tools/check_license.ts --check",
     "check:types": "deno check --unstable demo.ts mod.ts",
     "check": "deno task check:license && deno task check:types",
-    "test": "KV_PATH=:memory: deno test -A --unstable --allow-env --allow-read --parallel --doc --coverage=./cov",
+    "test": "KV_PATH=:memory: deno test --unstable --allow-env --allow-read --parallel --doc --coverage=./cov",
     "ok": "deno fmt --check && deno lint && deno task check && deno task test",
     "cov": "deno coverage ./cov/ --lcov --exclude='test.ts|testdata' > cov.lcov",
     "update": "deno run -A https://deno.land/x/udd/main.ts --test=\"deno task test\" deps.ts demo.ts"

--- a/src/_core.ts
+++ b/src/_core.ts
@@ -23,7 +23,7 @@ export const COOKIE_BASE = {
   sameSite: "Lax",
 } as Partial<Cookie>;
 
-const kv = await Deno.openKv();
+const kv = await Deno.openKv(":memory:");
 
 // For graceful shutdown after tests.
 addEventListener("beforeunload", async () => {

--- a/src/_core.ts
+++ b/src/_core.ts
@@ -18,12 +18,18 @@ export function getCookieName(name: string, isSecure: boolean) {
 export const COOKIE_BASE = {
   path: "/",
   httpOnly: true,
-  /** 90 days */
+  // 90 days
   maxAge: 7776000,
   sameSite: "Lax",
 } as Partial<Cookie>;
 
-const kv = await Deno.openKv(":memory:");
+const KV_PATH_KEY = "KV_PATH";
+const path =
+  (await Deno.permissions.query({ name: "env", variable: KV_PATH_KEY }))
+      .state === "granted"
+    ? Deno.env.get(KV_PATH_KEY)
+    : undefined;
+const kv = await Deno.openKv(path);
 
 // For graceful shutdown after tests.
 addEventListener("beforeunload", async () => {

--- a/src/_core.ts
+++ b/src/_core.ts
@@ -24,11 +24,13 @@ export const COOKIE_BASE = {
 } as Partial<Cookie>;
 
 const KV_PATH_KEY = "KV_PATH";
-const path =
+let path = undefined;
+if (
   (await Deno.permissions.query({ name: "env", variable: KV_PATH_KEY }))
-      .state === "granted"
-    ? Deno.env.get(KV_PATH_KEY)
-    : undefined;
+    .state === "granted"
+) {
+  path = Deno.env.get(KV_PATH_KEY);
+}
 const kv = await Deno.openKv(path);
 
 // For graceful shutdown after tests.

--- a/src/get_session_access_token_test.ts
+++ b/src/get_session_access_token_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { getSessionAccessToken } from "./get_session_access_token.ts";
 import { assertEquals, assertRejects, SECOND, Tokens } from "../dev_deps.ts";
-import { deleteStoredTokensBySession, setTokensBySession } from "./_core.ts";
+import { setTokensBySession } from "./_core.ts";
 import { oauth2Client } from "./_test_utils.ts";
 
 Deno.test("getSessionAccessToken()", async (test) => {
@@ -20,9 +20,6 @@ Deno.test("getSessionAccessToken()", async (test) => {
       await getSessionAccessToken(oauth2Client, sessionId),
       tokens.accessToken,
     );
-
-    // Cleanup
-    await deleteStoredTokensBySession(sessionId);
   });
 
   await test.step("returns the access token for session with far expiry", async () => {
@@ -38,9 +35,6 @@ Deno.test("getSessionAccessToken()", async (test) => {
       await getSessionAccessToken(oauth2Client, sessionId),
       tokens.accessToken,
     );
-
-    // Cleanup
-    await deleteStoredTokensBySession(sessionId);
   });
 
   await test.step("attempts to return a fresh access token for expired session", async () => {
@@ -55,8 +49,5 @@ Deno.test("getSessionAccessToken()", async (test) => {
     assertRejects(async () =>
       await getSessionAccessToken(oauth2Client, sessionId)
     );
-
-    // Cleanup
-    await deleteStoredTokensBySession(sessionId);
   });
 });

--- a/src/get_session_id_test.ts
+++ b/src/get_session_id_test.ts
@@ -1,10 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../dev_deps.ts";
-import {
-  deleteStoredTokensBySession,
-  setTokensBySession,
-  SITE_COOKIE_NAME,
-} from "./_core.ts";
+import { setTokensBySession, SITE_COOKIE_NAME } from "./_core.ts";
 import { getSessionId } from "./get_session_id.ts";
 
 Deno.test("getSessionId()", async (test) => {
@@ -34,8 +30,5 @@ Deno.test("getSessionId()", async (test) => {
       },
     });
     assertEquals(await getSessionId(request), sessionId);
-
-    // Cleanup
-    await deleteStoredTokensBySession(sessionId);
   });
 });

--- a/src/sign_in_test.ts
+++ b/src/sign_in_test.ts
@@ -7,11 +7,7 @@ import {
   getSetCookies,
   Status,
 } from "../dev_deps.ts";
-import {
-  deleteOAuthSession,
-  getOAuthSession,
-  OAUTH_COOKIE_NAME,
-} from "./_core.ts";
+import { getOAuthSession, OAUTH_COOKIE_NAME } from "./_core.ts";
 import { oauth2Client } from "./_test_utils.ts";
 
 Deno.test("signIn()", async (test) => {
@@ -42,7 +38,4 @@ Deno.test("signIn()", async (test) => {
     assert(oauthSession);
     assertEquals(oauthSession.state, state);
   });
-
-  // Cleanup
-  await deleteOAuthSession(setCookie.value);
 });

--- a/src/sign_out_test.ts
+++ b/src/sign_out_test.ts
@@ -2,7 +2,6 @@
 import { assertEquals, Status, type Tokens } from "../dev_deps.ts";
 import { signOut } from "./sign_out.ts";
 import {
-  deleteStoredTokensBySession,
   getTokensBySession,
   setTokensBySession,
   SITE_COOKIE_NAME,
@@ -39,7 +38,4 @@ Deno.test("signOut()", async (test) => {
   await test.step("deletes the tokens entry in KV", async () => {
     assertEquals(await getTokensBySession(sessionId), null);
   });
-
-  // Cleanup
-  await deleteStoredTokensBySession(sessionId);
 });


### PR DESCRIPTION
This change allows the user to define a `KV_PATH` environment variable to choose the KV's path. It works such that if `--allow-env` permissions aren't set, the code doesn't complain. By setting `KV_PATH=:memory:`, test cleanups are no longer needed.

Closes #88
Likely closes #87