### PR TITLE
perf: try eventual consistency first in `getSessionId()`

### DIFF
--- a/src/_core.ts
+++ b/src/_core.ts
@@ -113,11 +113,14 @@ export function toTokens(storedTokens: StoredTokens): Tokens {
  * Retrieves the token for the given session ID.
  * Before retrieval, the stored token is converted to a normal token using {@linkcode toTokens}.
  */
-export async function getTokensBySession(sessionId: string) {
+export async function getTokensBySession(
+  sessionId: string,
+  consistency?: Deno.KvConsistencyLevel,
+) {
   const result = await kv.get<StoredTokens>([
     STORED_TOKENS_BY_SESSION_PREFIX,
     sessionId,
-  ]);
+  ], { consistency });
   return result.value !== null ? toTokens(result.value) : null;
 }
 

--- a/src/get_session_id.ts
+++ b/src/get_session_id.ts
@@ -31,9 +31,13 @@ export async function getSessionId(request: Request) {
   const sessionId = getCookies(request.headers)[cookieName];
   if (sessionId === undefined) return null;
 
-  /**
-   * @todo Perhaps an eventual consistency check should happen first.
-   * Revisit this once more documentation about eventual consistency is published.
-   */
-  return await getTokensBySession(sessionId) !== null ? sessionId : null;
+  // First, try with eventual consistency. If that returns null, try with strong consistency.
+  if (
+    await getTokensBySession(sessionId, "eventual") ||
+    await getTokensBySession(sessionId)
+  ) {
+    return sessionId;
+  }
+
+  return null;
 }


### PR DESCRIPTION
Getting the token with strong consistency is now the fail-through.