### PR TITLE
doc: tweak imports in docs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,7 @@
 {
+  "imports": {
+    "https://deno.land/x/deno_kv_oauth@$VERSION/": "./"
+  },
   "tasks": {
     "demo": "deno run --allow-net --allow-env --allow-read --unstable --watch=demo.ts,mod.ts demo.ts",
     "check:license": "deno run -A tools/check_license.ts --check",

--- a/src/create_oauth2_client.ts
+++ b/src/create_oauth2_client.ts
@@ -16,7 +16,7 @@ type WithRedirectUri = { redirectUri: string };
  *
  * @example
  * ```ts
- * import { createDiscordOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createDiscordOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createDiscordOAuth2Client({
  *  redirectUri: "http://localhost:8000/callback",
@@ -52,7 +52,7 @@ export function createDiscordOAuth2Client(
  *
  * @example
  * ```ts
- * import { createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createGitHubOAuth2Client();
  * ```
@@ -82,7 +82,7 @@ export function createGitHubOAuth2Client(
  *
  * @example
  * ```ts
- * import { createGitLabOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createGitLabOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createGitLabOAuth2Client({
  *  redirectUri: "http://localhost:8000/callback",
@@ -120,7 +120,7 @@ export function createGitLabOAuth2Client(
  *
  * @example
  * ```ts
- * import { createGoogleOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createGoogleOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createGoogleOAuth2Client({
  *  redirectUri: "http://localhost:8000/callback",
@@ -158,7 +158,7 @@ export function createGoogleOAuth2Client(
  *
  * @example
  * ```ts
- * import { createSlackOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createSlackOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createSlackOAuth2Client({
  *  redirectUri: "http://localhost:8000/callback",
@@ -193,7 +193,7 @@ export function createSlackOAuth2Client(
  *
  * @example
  * ```ts
- * import { createTwitterOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createTwitterOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createTwitterOAuth2Client({
  *  redirectUri: "http://localhost:8000/callback",

--- a/src/get_session_access_token.ts
+++ b/src/get_session_access_token.ts
@@ -13,7 +13,7 @@ import { getTokensBySession, setTokensBySession } from "./_core.ts";
  *
  * @example.
  * ```ts
- * import { getSessionAccessToken, createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { getSessionAccessToken, createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createGitHubOAuth2Client();
  * const accessToken = await getSessionAccessToken(oauth2Client, "my-session-id");

--- a/src/get_session_id.ts
+++ b/src/get_session_id.ts
@@ -18,7 +18,7 @@ import {
  *
  * @example
  * ```ts
- * import { getSessionId } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { getSessionId } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * export async function handler(request: Request) {
  *   const sessionId = await getSessionId(request);

--- a/src/handle_callback.ts
+++ b/src/handle_callback.ts
@@ -28,7 +28,7 @@ import {
  *
  * @example
  * ```ts
- * import { handleCallback, createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { handleCallback, createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createGitHubOAuth2Client();
  *

--- a/src/sign_in.ts
+++ b/src/sign_in.ts
@@ -21,7 +21,7 @@ import {
  *
  * @example
  * ```ts
- * import { signIn, createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { signIn, createGitHubOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauth2Client = createGitHubOAuth2Client();
  *

--- a/src/sign_out.ts
+++ b/src/sign_out.ts
@@ -21,7 +21,7 @@ import { getSessionId } from "./get_session_id.ts";
  *
  * @example
  * ```ts
- * import { signOut } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { signOut } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * export async function signOutHandler(request: Request) {
  *   return await signOut(request, "/path-after-sign-out");


### PR DESCRIPTION
Previously, when checking docs, an error would be thrown because of a mismatch in functionality between the latest stable version of the module and the canary version of the module. This change fixes that.