### PR TITLE
refactor: DRY `createOAuth2Client()` tests

### DIFF
--- a/src/create_oauth2_client_test.ts
+++ b/src/create_oauth2_client_test.ts
@@ -1,54 +1,31 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../dev_deps.ts";
-import {
-  createDiscordOAuth2Client,
-  createGitHubOAuth2Client,
-  createGitLabOAuth2Client,
-  createGoogleOAuth2Client,
-  createSlackOAuth2Client,
-  createTwitterOAuth2Client,
-} from "./create_oauth2_client.ts";
+import * as createOAuth2ClientFns from "./create_oauth2_client.ts";
 
 [
-  {
-    createOAuth2ClientFn: createDiscordOAuth2Client,
-    provider: "Discord",
-  },
-  {
-    createOAuth2ClientFn: createGitHubOAuth2Client,
-    provider: "GitHub",
-  },
-  {
-    createOAuth2ClientFn: createGitLabOAuth2Client,
-    provider: "GitLab",
-  },
-  {
-    createOAuth2ClientFn: createGoogleOAuth2Client,
-    provider: "Google",
-  },
-  {
-    createOAuth2ClientFn: createSlackOAuth2Client,
-    provider: "Slack",
-  },
-  {
-    createOAuth2ClientFn: createTwitterOAuth2Client,
-    provider: "Twitter",
-  },
-].map((test) =>
-  Deno.test(`create${test.provider}OAuth2Client() returns the correctly configured client`, () => {
+  "Discord",
+  "GitHub",
+  "GitLab",
+  "Google",
+  "Slack",
+  "Twitter",
+].map((provider) => {
+  const fnName = `create${provider}OAuth2Client`;
+  Deno.test(`${fnName}() returns the correctly configured client`, () => {
     const clientId = crypto.randomUUID();
     const clientSecret = crypto.randomUUID();
     const redirectUri = "http://example.com";
     const defaults = { scope: "scope" };
 
-    const envKeyPrefix = test.provider.toUpperCase();
-    Deno.env.set(`${envKeyPrefix}_CLIENT_ID`, clientId);
-    Deno.env.set(`${envKeyPrefix}_CLIENT_SECRET`, clientSecret);
+    const envVarKeyPrefix = provider.toUpperCase();
+    Deno.env.set(`${envVarKeyPrefix}_CLIENT_ID`, clientId);
+    Deno.env.set(`${envVarKeyPrefix}_CLIENT_SECRET`, clientSecret);
 
-    const client = test.createOAuth2ClientFn({ redirectUri, defaults });
+    // @ts-ignore Trust me
+    const client = createOAuth2ClientFns[fnName]({ redirectUri, defaults });
     assertEquals(client.config.clientId, clientId);
     assertEquals(client.config.clientSecret, clientSecret);
     assertEquals(client.config.redirectUri, redirectUri);
     assertEquals(client.config.defaults, defaults);
-  })
-);
+  });
+});

--- a/src/create_oauth2_client_test.ts
+++ b/src/create_oauth2_client_test.ts
@@ -9,98 +9,46 @@ import {
   createTwitterOAuth2Client,
 } from "./create_oauth2_client.ts";
 
-Deno.test("createDiscordOAuth2Client() returns the correctly configured client", () => {
-  const clientId = crypto.randomUUID();
-  const clientSecret = crypto.randomUUID();
-  const redirectUri = "http://example.com";
-  const defaults = { scope: "scope" };
+[
+  {
+    createOAuth2ClientFn: createDiscordOAuth2Client,
+    provider: "Discord",
+  },
+  {
+    createOAuth2ClientFn: createGitHubOAuth2Client,
+    provider: "GitHub",
+  },
+  {
+    createOAuth2ClientFn: createGitLabOAuth2Client,
+    provider: "GitLab",
+  },
+  {
+    createOAuth2ClientFn: createGoogleOAuth2Client,
+    provider: "Google",
+  },
+  {
+    createOAuth2ClientFn: createSlackOAuth2Client,
+    provider: "Slack",
+  },
+  {
+    createOAuth2ClientFn: createTwitterOAuth2Client,
+    provider: "Twitter",
+  },
+].map((test) =>
+  Deno.test(`create${test.provider}OAuth2Client() returns the correctly configured client`, () => {
+    const clientId = crypto.randomUUID();
+    const clientSecret = crypto.randomUUID();
+    const redirectUri = "http://example.com";
+    const defaults = { scope: "scope" };
 
-  Deno.env.set("DISCORD_CLIENT_ID", clientId);
-  Deno.env.set("DISCORD_CLIENT_SECRET", clientSecret);
+    const envKeyPrefix = test.provider.toUpperCase();
+    Deno.env.set(`${envKeyPrefix}_CLIENT_ID`, clientId);
+    Deno.env.set(`${envKeyPrefix}_CLIENT_SECRET`, clientSecret);
 
-  const client = createDiscordOAuth2Client({ redirectUri, defaults });
-  assertEquals(client.config.clientId, clientId);
-  assertEquals(client.config.clientSecret, clientSecret);
-  assertEquals(client.config.redirectUri, redirectUri);
-  assertEquals(client.config.defaults, defaults);
-});
-
-Deno.test("createGitHubOAuth2Client() returns the correctly configured client", () => {
-  const clientId = crypto.randomUUID();
-  const clientSecret = crypto.randomUUID();
-  const redirectUri = "http://example.com";
-  const defaults = { scope: "scope" };
-
-  Deno.env.set("GITHUB_CLIENT_ID", clientId);
-  Deno.env.set("GITHUB_CLIENT_SECRET", clientSecret);
-
-  const client = createGitHubOAuth2Client({ redirectUri, defaults });
-  assertEquals(client.config.clientId, clientId);
-  assertEquals(client.config.clientSecret, clientSecret);
-  assertEquals(client.config.redirectUri, redirectUri);
-  assertEquals(client.config.defaults, defaults);
-});
-
-Deno.test("createGitLabOAuth2Client() returns the correctly configured client", () => {
-  const clientId = crypto.randomUUID();
-  const clientSecret = crypto.randomUUID();
-  const redirectUri = "http://example.com";
-  const defaults = { scope: "scope" };
-
-  Deno.env.set("GITLAB_CLIENT_ID", clientId);
-  Deno.env.set("GITLAB_CLIENT_SECRET", clientSecret);
-
-  const client = createGitLabOAuth2Client({ redirectUri, defaults });
-  assertEquals(client.config.clientId, clientId);
-  assertEquals(client.config.clientSecret, clientSecret);
-  assertEquals(client.config.redirectUri, redirectUri);
-  assertEquals(client.config.defaults, defaults);
-});
-
-Deno.test("createGoogleOAuth2Client() returns the correctly configured client", () => {
-  const clientId = crypto.randomUUID();
-  const clientSecret = crypto.randomUUID();
-  const redirectUri = "http://example.com";
-  const defaults = { scope: "scope" };
-
-  Deno.env.set("GOOGLE_CLIENT_ID", clientId);
-  Deno.env.set("GOOGLE_CLIENT_SECRET", clientSecret);
-
-  const client = createGoogleOAuth2Client({ redirectUri, defaults });
-  assertEquals(client.config.clientId, clientId);
-  assertEquals(client.config.clientSecret, clientSecret);
-  assertEquals(client.config.redirectUri, redirectUri);
-  assertEquals(client.config.defaults, defaults);
-});
-
-Deno.test("createSlackOAuth2Client() returns the correctly configured client", () => {
-  const clientId = crypto.randomUUID();
-  const clientSecret = crypto.randomUUID();
-  const redirectUri = "http://example.com";
-  const defaults = { scope: "scope" };
-
-  Deno.env.set("SLACK_CLIENT_ID", clientId);
-  Deno.env.set("SLACK_CLIENT_SECRET", clientSecret);
-
-  const client = createSlackOAuth2Client({ redirectUri, defaults });
-  assertEquals(client.config.clientId, clientId);
-  assertEquals(client.config.clientSecret, clientSecret);
-  assertEquals(client.config.redirectUri, redirectUri);
-  assertEquals(client.config.defaults, defaults);
-});
-
-Deno.test("createTwitterOAuth2Client() returns the correctly configured client", () => {
-  const clientId = crypto.randomUUID();
-  const clientSecret = crypto.randomUUID();
-  const redirectUri = "http://example.com";
-  const defaults = { scope: "scope" };
-
-  Deno.env.set("TWITTER_CLIENT_ID", clientId);
-  Deno.env.set("TWITTER_CLIENT_SECRET", clientSecret);
-
-  const client = createTwitterOAuth2Client({ redirectUri, defaults });
-  assertEquals(client.config.clientId, clientId);
-  assertEquals(client.config.clientSecret, clientSecret);
-  assertEquals(client.config.redirectUri, redirectUri);
-  assertEquals(client.config.defaults, defaults);
-});
+    const client = test.createOAuth2ClientFn({ redirectUri, defaults });
+    assertEquals(client.config.clientId, clientId);
+    assertEquals(client.config.clientSecret, clientSecret);
+    assertEquals(client.config.redirectUri, redirectUri);
+    assertEquals(client.config.defaults, defaults);
+  })
+);

--- a/src/create_oauth2_client_test.ts
+++ b/src/create_oauth2_client_test.ts
@@ -30,3 +30,4 @@ import * as createOAuth2ClientFns from "./create_oauth2_client.ts";
     assertEquals(client.config.redirectUri, redirectUri);
     assertEquals(client.config.defaults, defaults);
   });
+});


### PR DESCRIPTION
This'll make adding provider clients easier.