### PR TITLE
refactor: `isSecure()`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -6,7 +6,7 @@ export const SITE_COOKIE_NAME = "site-session";
 
 // Determines whether the request URL is of a secure origin using the HTTPS protocol.
 export function isSecure(requestUrl: string) {
-  return requestUrl.startsWith("https");
+  return new URL(requestUrl).protocol === "https:";
 }
 
 // Dynamically prefixes the cookie name, depending on whether it's for a secure origin (HTTPS).

--- a/src/core_test.ts
+++ b/src/core_test.ts
@@ -3,8 +3,10 @@ import { assert, assertEquals, Status, type Tokens } from "../dev_deps.ts";
 import {
   deleteOAuthSession,
   deleteStoredTokensBySession,
+  getCookieName,
   getOAuthSession,
   getTokensBySession,
+  isSecure,
   type OAuthSession,
   redirect,
   setOAuthSession,
@@ -12,6 +14,16 @@ import {
   toStoredTokens,
   toTokens,
 } from "./core.ts";
+
+Deno.test("isSecure() works correctly", () => {
+  assertEquals(isSecure("https://example.com"), true);
+  assertEquals(isSecure("http://example.com"), false);
+});
+
+Deno.test("getCookieName() works correctly", () => {
+  assertEquals(getCookieName("hello", true), "__Host-hello");
+  assertEquals(getCookieName("hello", false), "hello");
+});
 
 Deno.test("(get/set/delete)OAuthSession() work interchangeably", async () => {
   const id = crypto.randomUUID();

--- a/src/get_session_access_token_test.ts
+++ b/src/get_session_access_token_test.ts
@@ -37,12 +37,26 @@ Deno.test("getSessionAccessToken()", async (test) => {
     );
   });
 
-  await test.step("attempts to return a fresh access token for expired session", async () => {
+  await test.step("rejects for an expired access token", async () => {
     const sessionId = crypto.randomUUID();
     const tokens: Tokens = {
       accessToken: crypto.randomUUID(),
       tokenType: "Bearer",
       expiresIn: 0,
+      refreshToken: crypto.randomUUID(),
+    };
+    await setTokensBySession(sessionId, tokens);
+    assertRejects(async () =>
+      await getSessionAccessToken(oauth2Client, sessionId)
+    );
+  });
+
+  await test.step("rejects if the OAuth provider hasn't issued the access token", async () => {
+    const sessionId = crypto.randomUUID();
+    const tokens: Tokens = {
+      accessToken: crypto.randomUUID(),
+      tokenType: "Bearer",
+      expiresIn: 60,
       refreshToken: crypto.randomUUID(),
     };
     await setTokensBySession(sessionId, tokens);


### PR DESCRIPTION
This slight change ensures that `isSecure()` only accepts valid URLs. More testing for `getSessionAccessToken()` and `getCookieName()` are also included.