### PR TITLE
chore: check typos in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           deno-version: ${{ matrix.deno }}
+      
+      - name: Check typos
+        uses: crate-ci/typos@master
 
       - name: Check formatting, linting, types and run tests
         run: deno task ok

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
 
     steps:
       - name: Setup repo
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions/checkout@v3
 
       - name: Setup Deno

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
 
     steps:
       - name: Setup repo
-        if: matrix.os == 'ubuntu-22.04'
         uses: actions/checkout@v3
 
       - name: Setup Deno
@@ -31,6 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno }}
       
       - name: Check typos
+        if: matrix.os == 'ubuntu-22.04'
         uses: crate-ci/typos@master
 
       - name: Check formatting, linting, types and run tests


### PR DESCRIPTION
Done using the [typos GitHub action](https://github.com/crate-ci/typos/blob/master/docs/github-action.md).

Idea was taken from https://github.com/denoland/deno_std/pull/3459.