### PR TITLE
BREAKING: return `undefined` instead of `null` from `getSessionId()`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "deno.lint": true,
   "deno.enable": true,
   "deno.unstable": true,
   "editor.formatOnSave": true,

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ provider you like.
 
    async function handleAccountPage(request: Request) {
      const sessionId = await getSessionId(request);
-     const isSignedIn = sessionId !== null;
+     const isSignedIn = sessionId !== undefined;
 
      if (!isSignedIn) return new Response(null, { status: 404 });
 

--- a/demo.ts
+++ b/demo.ts
@@ -70,7 +70,7 @@ const oauth2Client = createOAuth2ClientFn(additionalOAuth2ClientConfig);
 
 async function indexHandler(request: Request) {
   const sessionId = await getSessionId(request);
-  const isSignedIn = sessionId !== null;
+  const isSignedIn = sessionId !== undefined;
   const accessToken = isSignedIn
     ? await getSessionAccessToken(oauth2Client, sessionId)
     : null;

--- a/src/get_session_id.ts
+++ b/src/get_session_id.ts
@@ -22,7 +22,7 @@ import {
  *
  * export async function handler(request: Request) {
  *   const sessionId = await getSessionId(request);
- *   const isSignedIn = sessionId !== null;
+ *   const isSignedIn = sessionId !== undefined;
  *
  *   return Response.json({ sessionId, isSignedIn });
  * }
@@ -31,7 +31,7 @@ import {
 export async function getSessionId(request: Request) {
   const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
   const sessionId = getCookies(request.headers)[cookieName];
-  if (sessionId === undefined) return null;
+  if (sessionId === undefined) return undefined;
 
   // First, try with eventual consistency. If that returns null, try with strong consistency.
   if (
@@ -41,5 +41,5 @@ export async function getSessionId(request: Request) {
     return sessionId;
   }
 
-  return null;
+  return undefined;
 }

--- a/src/get_session_id_test.ts
+++ b/src/get_session_id_test.ts
@@ -6,7 +6,7 @@ import { getSessionId } from "./get_session_id.ts";
 Deno.test("getSessionId()", async (test) => {
   await test.step("returns null for invalid cookie", async () => {
     const request = new Request("http://example.com");
-    assertEquals(await getSessionId(request), null);
+    assertEquals(await getSessionId(request), undefined);
   });
 
   await test.step("returns null for non-existent session ID", async () => {
@@ -15,7 +15,7 @@ Deno.test("getSessionId()", async (test) => {
         cookie: `${SITE_COOKIE_NAME}=nil`,
       },
     });
-    assertEquals(await getSessionId(request), null);
+    assertEquals(await getSessionId(request), undefined);
   });
 
   await test.step("returns valid session ID", async () => {

--- a/src/sign_out.ts
+++ b/src/sign_out.ts
@@ -30,7 +30,7 @@ import { getSessionId } from "./get_session_id.ts";
  */
 export async function signOut(request: Request, redirectUrl = "/") {
   const sessionId = await getSessionId(request);
-  if (sessionId === null) return redirect(redirectUrl);
+  if (sessionId === undefined) return redirect(redirectUrl);
 
   await deleteStoredTokensBySession(sessionId);
 


### PR DESCRIPTION
This allows for `fn(sessionId?: string)` instead of `fn(sessionId: string | null)` and seems more intuitive, IMO.