### PR TITLE
feat: option to append URL params to authorization URI for `signIn()`

### DIFF
--- a/src/sign_in.ts
+++ b/src/sign_in.ts
@@ -34,6 +34,7 @@ export async function signIn(
   request: Request,
   oauth2Client: OAuth2Client,
   options?: {
+    /** These values will be appended to the authorization URI as parameters, if defined. */
     urlParams?: Record<string, string>;
   },
 ): Promise<Response> {

--- a/src/sign_in.ts
+++ b/src/sign_in.ts
@@ -34,7 +34,7 @@ export async function signIn(
   request: Request,
   oauth2Client: OAuth2Client,
   options?: {
-    /** These values will be appended to the authorization URI as parameters, if defined. */
+    /** These parameters will be appended to the authorization URI, if defined. */
     urlParams?: Record<string, string>;
   },
 ): Promise<Response> {

--- a/src/sign_in.ts
+++ b/src/sign_in.ts
@@ -62,7 +62,7 @@ export async function signIn(
 }
 
 /**
- * Handles additional paramaters that will be appended to the authorization uri
+ * Handles additional parameters that will be appended to the authorization uri
  */
 export async function getAuthorizationUri(
   oauth2Client: OAuth2Client,

--- a/src/sign_in.ts
+++ b/src/sign_in.ts
@@ -36,15 +36,10 @@ export async function signIn(
     options?: { urlParams?: Record<string, string> }
 ): Promise<Response> {
     const state = crypto.randomUUID();
-    const { uri, codeVerifier } = await oauth2Client.code.getAuthorizationUri({
+    const { uri, codeVerifier } = await getAuthorizationUri(oauth2Client, {
         state,
+        ...options,
     });
-
-    if (options?.urlParams) {
-        Object.entries(options.urlParams).forEach(([key, value]) =>
-            uri.searchParams.append(key, value)
-        );
-    }
 
     const oauthSessionId = crypto.randomUUID();
     await setOAuthSession(oauthSessionId, { state, codeVerifier });
@@ -64,4 +59,24 @@ export async function signIn(
         maxAge: 10 * 60,
     });
     return response;
+}
+
+/**
+ * Handles additional paramaters that will be appended to the authorization uri
+ */
+export async function getAuthorizationUri(
+    oauth2Client: OAuth2Client,
+    { urlParams, state }: { urlParams?: Record<string, string>; state: string }
+) {
+    const { uri, ...rest } = await oauth2Client.code.getAuthorizationUri({
+        state,
+    });
+
+    if (urlParams) {
+        Object.entries(urlParams).forEach(([key, value]) =>
+            uri.searchParams.append(key, value)
+        );
+    }
+
+    return { uri, ...rest };
 }

--- a/src/sign_in.ts
+++ b/src/sign_in.ts
@@ -1,12 +1,12 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { type OAuth2Client, setCookie } from "../deps.ts";
 import {
-    COOKIE_BASE,
-    getCookieName,
-    isSecure,
-    OAUTH_COOKIE_NAME,
-    redirect,
-    setOAuthSession,
+  COOKIE_BASE,
+  getCookieName,
+  isSecure,
+  OAUTH_COOKIE_NAME,
+  redirect,
+  setOAuthSession,
 } from "./core.ts";
 
 /**
@@ -31,52 +31,52 @@ import {
  * ```
  */
 export async function signIn(
-    request: Request,
-    oauth2Client: OAuth2Client,
-    options?: { urlParams?: Record<string, string> }
+  request: Request,
+  oauth2Client: OAuth2Client,
+  options?: { urlParams?: Record<string, string> },
 ): Promise<Response> {
-    const state = crypto.randomUUID();
-    const { uri, codeVerifier } = await getAuthorizationUri(oauth2Client, {
-        state,
-        ...options,
-    });
+  const state = crypto.randomUUID();
+  const { uri, codeVerifier } = await getAuthorizationUri(oauth2Client, {
+    state,
+    ...options,
+  });
 
-    const oauthSessionId = crypto.randomUUID();
-    await setOAuthSession(oauthSessionId, { state, codeVerifier });
+  const oauthSessionId = crypto.randomUUID();
+  await setOAuthSession(oauthSessionId, { state, codeVerifier });
 
-    const response = redirect(uri.toString());
-    setCookie(response.headers, {
-        ...COOKIE_BASE,
-        name: getCookieName(OAUTH_COOKIE_NAME, isSecure(request.url)),
-        value: oauthSessionId,
-        secure: isSecure(request.url),
-        /**
-         * A maximum authorization code lifetime of 10 minutes is recommended.
-         * This cookie lifetime matches that value.
-         *
-         * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2}
-         */
-        maxAge: 10 * 60,
-    });
-    return response;
+  const response = redirect(uri.toString());
+  setCookie(response.headers, {
+    ...COOKIE_BASE,
+    name: getCookieName(OAUTH_COOKIE_NAME, isSecure(request.url)),
+    value: oauthSessionId,
+    secure: isSecure(request.url),
+    /**
+     * A maximum authorization code lifetime of 10 minutes is recommended.
+     * This cookie lifetime matches that value.
+     *
+     * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2}
+     */
+    maxAge: 10 * 60,
+  });
+  return response;
 }
 
 /**
  * Handles additional paramaters that will be appended to the authorization uri
  */
 export async function getAuthorizationUri(
-    oauth2Client: OAuth2Client,
-    { urlParams, state }: { urlParams?: Record<string, string>; state: string }
+  oauth2Client: OAuth2Client,
+  { urlParams, state }: { urlParams?: Record<string, string>; state: string },
 ) {
-    const { uri, ...rest } = await oauth2Client.code.getAuthorizationUri({
-        state,
-    });
+  const { uri, ...rest } = await oauth2Client.code.getAuthorizationUri({
+    state,
+  });
 
-    if (urlParams) {
-        Object.entries(urlParams).forEach(([key, value]) =>
-            uri.searchParams.append(key, value)
-        );
-    }
+  if (urlParams) {
+    Object.entries(urlParams).forEach(([key, value]) =>
+      uri.searchParams.append(key, value)
+    );
+  }
 
-    return { uri, ...rest };
+  return { uri, ...rest };
 }

--- a/src/sign_in_test.ts
+++ b/src/sign_in_test.ts
@@ -1,41 +1,53 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { signIn } from "./sign_in.ts";
+import { signIn, getAuthorizationUri } from "./sign_in.ts";
 import {
-  assert,
-  assertEquals,
-  assertNotEquals,
-  getSetCookies,
-  Status,
+    assert,
+    assertEquals,
+    assertNotEquals,
+    getSetCookies,
+    Status,
 } from "../dev_deps.ts";
 import { getOAuthSession, OAUTH_COOKIE_NAME } from "./core.ts";
 import { oauth2Client } from "./test_utils.ts";
 
 Deno.test("signIn()", async (test) => {
-  const request = new Request("http://my-site.com");
-  const response = await signIn(request, oauth2Client);
+    const request = new Request("http://my-site.com");
+    const response = await signIn(request, oauth2Client);
 
-  await test.step("returns a redirect response", () => {
-    assertEquals(response.body, null);
-    assertNotEquals(response.headers.get("location"), null);
-    assertEquals(response.status, Status.Found);
-  });
+    await test.step("returns a redirect response", () => {
+        assertEquals(response.body, null);
+        assertNotEquals(response.headers.get("location"), null);
+        assertEquals(response.status, Status.Found);
+    });
 
-  const [setCookie] = getSetCookies(response.headers);
-  await test.step("correctly sets the session cookie", () => {
-    assertEquals(setCookie.name, OAUTH_COOKIE_NAME);
-    assertEquals(setCookie.httpOnly, true);
-    assertEquals(setCookie.maxAge, 10 * 60);
-    assertEquals(setCookie.sameSite, "Lax");
-    assertEquals(setCookie.path, "/");
-  });
+    const [setCookie] = getSetCookies(response.headers);
+    await test.step("correctly sets the session cookie", () => {
+        assertEquals(setCookie.name, OAUTH_COOKIE_NAME);
+        assertEquals(setCookie.httpOnly, true);
+        assertEquals(setCookie.maxAge, 10 * 60);
+        assertEquals(setCookie.sameSite, "Lax");
+        assertEquals(setCookie.path, "/");
+    });
 
-  await test.step("correctly sets the OAuth 2.0 session entry in KV", async () => {
-    const oauthSessionId = setCookie.value;
-    const oauthSession = await getOAuthSession(oauthSessionId);
-    const state = new URL(response.headers.get("location")!).searchParams.get(
-      "state",
-    );
-    assert(oauthSession);
-    assertEquals(oauthSession.state, state);
-  });
+    await test.step("correctly sets the OAuth 2.0 session entry in KV", async () => {
+        const oauthSessionId = setCookie.value;
+        const oauthSession = await getOAuthSession(oauthSessionId);
+        const state = new URL(
+            response.headers.get("location")!
+        ).searchParams.get("state");
+        assert(oauthSession);
+        assertEquals(oauthSession?.state, state);
+    });
+});
+
+Deno.test("withOptions()", async (test) => {
+    const state = crypto.randomUUID();
+    const { uri } = await getAuthorizationUri(oauth2Client, {
+        state,
+        urlParams: { foo: "bar" },
+    });
+
+    await test.step("correctly add additional params to the authorization url", () => {
+        assertEquals(uri.searchParams.get("foo"), "bar");
+    });
 });

--- a/src/sign_in_test.ts
+++ b/src/sign_in_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { getAuthorizationUri, signIn } from "./sign_in.ts";
+import { signIn } from "./sign_in.ts";
 import {
   assert,
   assertEquals,
@@ -38,16 +38,18 @@ Deno.test("signIn()", async (test) => {
     assert(oauthSession);
     assertEquals(oauthSession?.state, state);
   });
-});
 
-Deno.test("withOptions()", async (test) => {
-  const state = crypto.randomUUID();
-  const { uri } = await getAuthorizationUri(oauth2Client, {
-    state,
-    urlParams: { foo: "bar" },
-  });
+  await test.step("returns a redirect response with URL params", async () => {
+    const responseWithUrlParams = await signIn(request, oauth2Client, {
+      urlParams: { foo: "bar" },
+    });
 
-  await test.step("correctly add additional params to the authorization url", () => {
-    assertEquals(uri.searchParams.get("foo"), "bar");
+    const location = responseWithUrlParams.headers.get("location");
+    assert(location !== null);
+
+    const url = new URL(location);
+    assertEquals(responseWithUrlParams.body, null);
+    assertEquals(url.searchParams.get("foo"), "bar");
+    assertEquals(responseWithUrlParams.status, Status.Found);
   });
 });

--- a/src/sign_in_test.ts
+++ b/src/sign_in_test.ts
@@ -1,53 +1,53 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { signIn, getAuthorizationUri } from "./sign_in.ts";
+import { getAuthorizationUri, signIn } from "./sign_in.ts";
 import {
-    assert,
-    assertEquals,
-    assertNotEquals,
-    getSetCookies,
-    Status,
+  assert,
+  assertEquals,
+  assertNotEquals,
+  getSetCookies,
+  Status,
 } from "../dev_deps.ts";
 import { getOAuthSession, OAUTH_COOKIE_NAME } from "./core.ts";
 import { oauth2Client } from "./test_utils.ts";
 
 Deno.test("signIn()", async (test) => {
-    const request = new Request("http://my-site.com");
-    const response = await signIn(request, oauth2Client);
+  const request = new Request("http://my-site.com");
+  const response = await signIn(request, oauth2Client);
 
-    await test.step("returns a redirect response", () => {
-        assertEquals(response.body, null);
-        assertNotEquals(response.headers.get("location"), null);
-        assertEquals(response.status, Status.Found);
-    });
+  await test.step("returns a redirect response", () => {
+    assertEquals(response.body, null);
+    assertNotEquals(response.headers.get("location"), null);
+    assertEquals(response.status, Status.Found);
+  });
 
-    const [setCookie] = getSetCookies(response.headers);
-    await test.step("correctly sets the session cookie", () => {
-        assertEquals(setCookie.name, OAUTH_COOKIE_NAME);
-        assertEquals(setCookie.httpOnly, true);
-        assertEquals(setCookie.maxAge, 10 * 60);
-        assertEquals(setCookie.sameSite, "Lax");
-        assertEquals(setCookie.path, "/");
-    });
+  const [setCookie] = getSetCookies(response.headers);
+  await test.step("correctly sets the session cookie", () => {
+    assertEquals(setCookie.name, OAUTH_COOKIE_NAME);
+    assertEquals(setCookie.httpOnly, true);
+    assertEquals(setCookie.maxAge, 10 * 60);
+    assertEquals(setCookie.sameSite, "Lax");
+    assertEquals(setCookie.path, "/");
+  });
 
-    await test.step("correctly sets the OAuth 2.0 session entry in KV", async () => {
-        const oauthSessionId = setCookie.value;
-        const oauthSession = await getOAuthSession(oauthSessionId);
-        const state = new URL(
-            response.headers.get("location")!
-        ).searchParams.get("state");
-        assert(oauthSession);
-        assertEquals(oauthSession?.state, state);
-    });
+  await test.step("correctly sets the OAuth 2.0 session entry in KV", async () => {
+    const oauthSessionId = setCookie.value;
+    const oauthSession = await getOAuthSession(oauthSessionId);
+    const state = new URL(
+      response.headers.get("location")!,
+    ).searchParams.get("state");
+    assert(oauthSession);
+    assertEquals(oauthSession?.state, state);
+  });
 });
 
 Deno.test("withOptions()", async (test) => {
-    const state = crypto.randomUUID();
-    const { uri } = await getAuthorizationUri(oauth2Client, {
-        state,
-        urlParams: { foo: "bar" },
-    });
+  const state = crypto.randomUUID();
+  const { uri } = await getAuthorizationUri(oauth2Client, {
+    state,
+    urlParams: { foo: "bar" },
+  });
 
-    await test.step("correctly add additional params to the authorization url", () => {
-        assertEquals(uri.searchParams.get("foo"), "bar");
-    });
+  await test.step("correctly add additional params to the authorization url", () => {
+    assertEquals(uri.searchParams.get("foo"), "bar");
+  });
 });


### PR DESCRIPTION
This was mainly to resolve an issue with Auth0 tokens but may useful for other oauth2 providers.

For Auth0 specifically, if an `audience` search parameter isn't provided then the resulting token is an opaque one, with no body.

![](https://github.com/denoland/deno_kv_oauth/assets/34522491/ca2a202f-1f6f-45ac-820b-208ea00f9e5a)

This means that the token cannot be used in conjunction with the [Auth0 APIs.](https://auth0.com/docs/api) This fix should hopefully fix that for Auth0 tokens (and by extension other providers should they also need additional url parameters to be added).

Example of the access token that is sent back to the end user with the possible patch

![](https://github.com/denoland/deno_kv_oauth/assets/34522491/732b752d-648b-4ad9-89fb-306265441d0a)