### PR TITLE
refactor: use `Deno.serve()` in demo

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -1,10 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import {
-  loadSync,
-  type OAuth2ClientConfig,
-  serve,
-  Status,
-} from "./dev_deps.ts";
+import { loadSync, type OAuth2ClientConfig, Status } from "./dev_deps.ts";
 import {
   createAuth0OAuth2Client,
   createDiscordOAuth2Client,
@@ -133,5 +128,5 @@ export async function handler(request: Request): Promise<Response> {
 }
 
 if (import.meta.main) {
-  await serve(handler);
+  Deno.serve(handler);
 }

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -9,6 +9,5 @@ export {
 } from "https://deno.land/std@0.194.0/testing/asserts.ts";
 export { walk } from "https://deno.land/std@0.194.0/fs/walk.ts";
 export { globToRegExp } from "https://deno.land/std@0.194.0/path/glob.ts";
-export { serve } from "https://deno.land/std@0.194.0/http/server.ts";
 export { loadSync } from "https://deno.land/std@0.194.0/dotenv/mod.ts";
 export * from "./deps.ts";


### PR DESCRIPTION
Deno Deploy now supports `Deno.serve()`.