### PR TITLE
BREAKING: remove KV call from `getSessionId()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ provider you like.
    const oauth2Client = createGitHubOAuth2Client();
 
    async function handleAccountPage(request: Request) {
-     const sessionId = await getSessionId(request);
+     const sessionId = getSessionId(request);
      const isSignedIn = sessionId !== undefined;
 
      if (!isSignedIn) return new Response(null, { status: 404 });

--- a/demo.ts
+++ b/demo.ts
@@ -69,8 +69,8 @@ const oauth2Client = createOAuth2ClientFn(additionalOAuth2ClientConfig);
 
 async function indexHandler(request: Request) {
   const sessionId = getSessionId(request);
-  const isSignedIn = sessionId !== undefined;
-  const accessToken = isSignedIn
+  const hasSessionIdCookie = sessionId !== undefined;
+  const accessToken = hasSessionIdCookie
     ? await getSessionAccessToken(oauth2Client, sessionId)
     : null;
 
@@ -80,7 +80,7 @@ async function indexHandler(request: Request) {
   const body = `
     <p>Provider: ${provider}</p>
     <p>Scope: ${oauth2Client.config.defaults?.scope}</p>
-    <p>Signed in: ${isSignedIn}</p>
+    <p>Signed in: ${hasSessionIdCookie}</p>
     <p>Your access token: ${accessTokenInnerText}</p>
     <p>
       <a href="/signin">Sign in</a>

--- a/demo.ts
+++ b/demo.ts
@@ -68,7 +68,7 @@ const additionalOAuth2ClientConfig: Partial<OAuth2ClientConfig> = {
 const oauth2Client = createOAuth2ClientFn(additionalOAuth2ClientConfig);
 
 async function indexHandler(request: Request) {
-  const sessionId = await getSessionId(request);
+  const sessionId = getSessionId(request);
   const isSignedIn = sessionId !== undefined;
   const accessToken = isSignedIn
     ? await getSessionAccessToken(oauth2Client, sessionId)

--- a/src/get_session_access_token.ts
+++ b/src/get_session_access_token.ts
@@ -23,7 +23,7 @@ export async function getSessionAccessToken(
   oauth2Client: OAuth2Client,
   sessionId: string,
 ) {
-  // First, try with eventual consistency. If that returns undefined, try with strong consistency.
+  // First, try with eventual consistency. If that returns null, try with strong consistency.
   const tokens = await getTokensBySession(sessionId, "eventual") ||
     await getTokensBySession(sessionId);
   if (tokens === null) return null;

--- a/src/get_session_access_token.ts
+++ b/src/get_session_access_token.ts
@@ -23,7 +23,9 @@ export async function getSessionAccessToken(
   oauth2Client: OAuth2Client,
   sessionId: string,
 ) {
-  const tokens = await getTokensBySession(sessionId);
+  // First, try with eventual consistency. If that returns undefined, try with strong consistency.
+  const tokens = await getTokensBySession(sessionId, "eventual") ||
+    await getTokensBySession(sessionId);
   if (tokens === null) return null;
   if (
     tokens.refreshToken === undefined ||

--- a/src/get_session_id.ts
+++ b/src/get_session_id.ts
@@ -15,9 +15,9 @@ import { getCookieName, isSecure, SITE_COOKIE_NAME } from "./core.ts";
  *
  * export function handler(request: Request) {
  *   const sessionId = getSessionId(request);
- *   const isSignedIn = sessionId !== undefined;
+ *   const hasSessionIdCookie = sessionId !== undefined;
  *
- *   return Response.json({ sessionId, isSignedIn });
+ *   return Response.json({ sessionId, hasSessionIdCookie });
  * }
  * ```
  */

--- a/src/get_session_id.ts
+++ b/src/get_session_id.ts
@@ -1,18 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { getCookies } from "../deps.ts";
-import {
-  getCookieName,
-  getTokensBySession,
-  isSecure,
-  SITE_COOKIE_NAME,
-} from "./core.ts";
+import { getCookieName, isSecure, SITE_COOKIE_NAME } from "./core.ts";
 
 /**
- * Gets the session ID for a given request. This is well-suited for checking whether the client is signed in by checking if nullish.
+ * Gets the session ID for a given request. This is well-suited for checking whether the client is signed in by checking if undefined.
  *
- * It does this by:
- * 1. Getting the session ID from the cookie in the given request. If the request has no cookie, null is returned.
- * 2. Getting the OAuth 2.0 session object using the session ID from KV. If the OAuth 2.0 token doesn't exist, null is returned.
+ * It does this by getting the session ID from the cookie in the given request. If the request has no cookie, undefined is returned.
  *
  * @param request The HTTP request from the client.
  *
@@ -20,26 +13,15 @@ import {
  * ```ts
  * import { getSessionId } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
- * export async function handler(request: Request) {
- *   const sessionId = await getSessionId(request);
+ * export function handler(request: Request) {
+ *   const sessionId = getSessionId(request);
  *   const isSignedIn = sessionId !== undefined;
  *
  *   return Response.json({ sessionId, isSignedIn });
  * }
  * ```
  */
-export async function getSessionId(request: Request) {
+export function getSessionId(request: Request) {
   const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
-  const sessionId = getCookies(request.headers)[cookieName];
-  if (sessionId === undefined) return undefined;
-
-  // First, try with eventual consistency. If that returns null, try with strong consistency.
-  if (
-    await getTokensBySession(sessionId, "eventual") ||
-    await getTokensBySession(sessionId)
-  ) {
-    return sessionId;
-  }
-
-  return undefined;
+  return getCookies(request.headers)[cookieName] as string | undefined;
 }

--- a/src/get_session_id_test.ts
+++ b/src/get_session_id_test.ts
@@ -1,34 +1,21 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../dev_deps.ts";
-import { setTokensBySession, SITE_COOKIE_NAME } from "./core.ts";
+import { SITE_COOKIE_NAME } from "./core.ts";
 import { getSessionId } from "./get_session_id.ts";
 
 Deno.test("getSessionId()", async (test) => {
-  await test.step("returns null for invalid cookie", async () => {
+  await test.step("returns undefined when cookie is not defined", () => {
     const request = new Request("http://example.com");
-    assertEquals(await getSessionId(request), undefined);
+    assertEquals(getSessionId(request), undefined);
   });
 
-  await test.step("returns null for non-existent session ID", async () => {
-    const request = new Request("http://example.com", {
-      headers: {
-        cookie: `${SITE_COOKIE_NAME}=nil`,
-      },
-    });
-    assertEquals(await getSessionId(request), undefined);
-  });
-
-  await test.step("returns valid session ID", async () => {
+  await test.step("returns valid session ID", () => {
     const sessionId = crypto.randomUUID();
-    await setTokensBySession(sessionId, {
-      accessToken: crypto.randomUUID(),
-      tokenType: crypto.randomUUID(),
-    });
     const request = new Request("http://example.com", {
       headers: {
         cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
       },
     });
-    assertEquals(await getSessionId(request), sessionId);
+    assertEquals(getSessionId(request), sessionId);
   });
 });

--- a/src/sign_out.ts
+++ b/src/sign_out.ts
@@ -29,7 +29,7 @@ import { getSessionId } from "./get_session_id.ts";
  * ```
  */
 export async function signOut(request: Request, redirectUrl = "/") {
-  const sessionId = await getSessionId(request);
+  const sessionId = getSessionId(request);
   if (sessionId === undefined) return redirect(redirectUrl);
 
   await deleteStoredTokensBySession(sessionId);


### PR DESCRIPTION
Previously, `getSessionId()` did two things before returning the session ID:
1. Retrieved the cookie value (session ID) from the request object.
2. Checked whether that session object exists in KV.

This change removes step two. `getSessionId()` is often used with `getSessionAccessToken()`, and `getSessionAccessToken()` also retrieves said session object. So, when used together, two getters for the session object in KV are made.

Now, `getSessionId()` just gets the session ID from the cookie value in the request.

Thanks to @adoublef for pointing this out!

Concerns:
1. Is `getSessionId()` still a valid and reasonable method of checking whether the client is signed in? I think so.
2. Could `getSessionId()` be renamed to communicate more clearly that this function is only concerned with getting the session cookie value and not anything KV-related? I don't feel strongly about this, but some suggestions would be `getSessionIdFromCookie()` or `getCookieSessionId()`.