### PR TITLE
feat: `createTwitchOAuth2Client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ following providers:
 1. [Patreon](https://deno.land/x/deno_kv_oauth/mod.ts?s=createPatreonOAuth2Client)
 1. [Slack](https://deno.land/x/deno_kv_oauth/mod.ts?s=createSlackOAuth2Client)
 1. [Spotify](https://deno.land/x/deno_kv_oauth/mod.ts?s=createSpotifyOAuth2Client)
+1. [Twitch](https://deno.land/x/deno_kv_oauth/mod.ts?s=createTwitchOAuth2Client)
 1. [Twitter](https://deno.land/x/deno_kv_oauth/mod.ts?s=createTwitterOAuth2Client)
 
 Each function is typed so that their respective platform's requirements are met.

--- a/demo.ts
+++ b/demo.ts
@@ -13,6 +13,7 @@ import {
   createPatreonOAuth2Client,
   createSlackOAuth2Client,
   createSpotifyOAuth2Client,
+  createTwitchOAuth2Client,
   createTwitterOAuth2Client,
   getSessionAccessToken,
   getSessionId,
@@ -48,6 +49,7 @@ const createOAuth2ClientFn = {
   Patreon: createPatreonOAuth2Client,
   Slack: createSlackOAuth2Client,
   Spotify: createSpotifyOAuth2Client,
+  Twitch: createTwitchOAuth2Client,
   Twitter: createTwitterOAuth2Client,
 }[provider];
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -12,4 +12,5 @@ export * from "./providers/okta.ts";
 export * from "./providers/patreon.ts";
 export * from "./providers/slack.ts";
 export * from "./providers/spotify.ts";
+export * from "./providers/twitch.ts";
 export * from "./providers/twitter.ts";

--- a/src/providers/twitch.ts
+++ b/src/providers/twitch.ts
@@ -1,0 +1,42 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
+import { OAuth2Client, OAuth2ClientConfig } from "../../deps.ts";
+import type { WithRedirectUri, WithScope } from "./_types.ts";
+
+/**
+ * Creates an OAuth 2.0 client with Twitch as the provider.
+ *
+ * Requires `--allow-env[=TWITCH_CLIENT_ID,TWITCH_CLIENT_SECRET]` permissions and environment variables:
+ * 1. `TWITCH_CLIENT_ID`
+ * 2. `TWITCH_CLIENT_SECRET`
+ *
+ * @param additionalOAuth2ClientConfig Requires `redirectUri` and `defaults.scope` properties.
+ *
+ * @example
+ * ```ts
+ * import { createTwitchOAuth2Client } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+ *
+ * const oauth2Client = createTwitchOAuth2Client({
+ *  redirectUri: "http://localhost:8000/callback",
+ *  defaults: {
+ *    scope: "moderator:read:followers"
+ *  }
+ * });
+ * ```
+ *
+ * @see {@link https://dev.twitch.tv/docs/authentication/}
+ */
+export function createTwitchOAuth2Client(
+  additionalOAuth2ClientConfig:
+    & Partial<OAuth2ClientConfig>
+    & WithRedirectUri
+    & WithScope,
+): OAuth2Client {
+  return new OAuth2Client({
+    clientId: Deno.env.get("TWITCH_CLIENT_ID")!,
+    clientSecret: Deno.env.get("TWITCH_CLIENT_SECRET")!,
+    authorizationEndpointUri: "https://id.twitch.tv/oauth2/authorize",
+    tokenUri: "https://id.twitch.tv/oauth2/token",
+    ...additionalOAuth2ClientConfig,
+  });
+}

--- a/src/providers/twitch.ts
+++ b/src/providers/twitch.ts
@@ -42,6 +42,7 @@ export function createTwitchOAuth2Client(
     tokenUri: "https://id.twitch.tv/oauth2/token",
     ...additionalOAuth2ClientConfig,
     defaults: {
+      ...additionalOAuth2ClientConfig.defaults,
       requestOptions: {
         ...additionalOAuth2ClientConfig.defaults.requestOptions,
         urlParams: {
@@ -50,7 +51,6 @@ export function createTwitchOAuth2Client(
           client_secret: clientSecret,
         },
       },
-      ...additionalOAuth2ClientConfig.defaults,
     },
   });
 }

--- a/src/providers/twitch.ts
+++ b/src/providers/twitch.ts
@@ -32,11 +32,23 @@ export function createTwitchOAuth2Client(
     & WithRedirectUri
     & WithScope,
 ): OAuth2Client {
+  const clientId = Deno.env.get("TWITCH_CLIENT_ID")!;
+  const clientSecret = Deno.env.get("TWITCH_CLIENT_SECRET")!;
+
   return new OAuth2Client({
-    clientId: Deno.env.get("TWITCH_CLIENT_ID")!,
-    clientSecret: Deno.env.get("TWITCH_CLIENT_SECRET")!,
+    clientId,
+    clientSecret,
     authorizationEndpointUri: "https://id.twitch.tv/oauth2/authorize",
     tokenUri: "https://id.twitch.tv/oauth2/token",
     ...additionalOAuth2ClientConfig,
+    defaults: {
+      requestOptions: {
+        urlParams: {
+          client_id: clientId,
+          client_secret: clientSecret,
+        },
+      },
+      ...additionalOAuth2ClientConfig.defaults,
+    },
   });
 }

--- a/src/providers/twitch.ts
+++ b/src/providers/twitch.ts
@@ -43,7 +43,9 @@ export function createTwitchOAuth2Client(
     ...additionalOAuth2ClientConfig,
     defaults: {
       requestOptions: {
+        ...additionalOAuth2ClientConfig.defaults.requestOptions,
         urlParams: {
+          ...additionalOAuth2ClientConfig.defaults.requestOptions?.urlParams,
           client_id: clientId,
           client_secret: clientSecret,
         },

--- a/src/providers_test.ts
+++ b/src/providers_test.ts
@@ -15,6 +15,7 @@ import * as createOAuth2ClientFns from "./providers.ts";
   "Patreon",
   "Slack",
   "Spotify",
+  "Twitch",
   "Twitter",
 ].map((provider) => {
   const fnName = `create${provider}OAuth2Client`;


### PR DESCRIPTION
This change is dependent on https://github.com/cmd-johnson/deno-oauth2-client/pull/36, since Twitch gives scopes as an array of strings in its `/token` response. Because of this, this PR should not be merged until that PR is approved/merged/released and we update the deps here.

One other thing that Twitch requires is the `client_id` and `client_secret` query params when making the `POST` request to `/token`. I've included this change in the config. Let me know if I missed anything when spreading `additionalOAuth2ClientConfig`

When tested against my changes there, it is working:
![image](https://github.com/denoland/deno_kv_oauth/assets/25411268/f57c3b32-9e66-4a8c-be27-f5d0ea9f94eb)

LMK if I need anything else 👍 