### PR TITLE
feat: `clearOAuthSessionsAndTokens()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ provider you like.
 
 > Check out a full implementation in the [demo source code](./demo.ts).
 
+1. When needed, you can delete all KV-stored OAuth 2.0 sessions and tokens.
+
+   ```ts
+   import { clearOAuthSessionsAndTokens } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+
+   await clearOAuthSessionsAndTokens();
+   ```
+
 ### Pre-configured OAuth 2.0 Clients
 
 This module comes with a suite of pre-configured OAuth 2.0 clients for the

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 export * from "./src/providers.ts";
+export * from "./src/clear_oauth_sessions_and_tokens.ts";
 export * from "./src/get_session_access_token.ts";
 export * from "./src/handle_callback.ts";
 export * from "./src/get_session_id.ts";

--- a/src/clear_oauth_sessions_and_tokens.ts
+++ b/src/clear_oauth_sessions_and_tokens.ts
@@ -1,0 +1,37 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import {
+  deleteOAuthSession,
+  deleteStoredTokensBySession,
+  listOAuthSessions,
+  listTokens,
+} from "./core.ts";
+
+/**
+ * Deletes all OAuth 2.0 sessions and tokens stored in KV.
+ *
+ * It does this by:
+ * 1. Listing all OAuth 2.0 session entries and asynchronously deleting them.
+ * 2. Listing all token entries and asynchronously deleting them.
+ * 3. Waiting for all deletion tasks to complete.
+ *
+ * @example
+ * ```ts
+ * import { clearOAuthSessionsAndTokens } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+ *
+ * await clearOAuthSessionsAndTokens();
+ * ```
+ */
+export async function clearOAuthSessionsAndTokens() {
+  const oauthSessionsIter = listOAuthSessions();
+  const tokensIter = listTokens();
+  const promises = [];
+  for await (const entry of oauthSessionsIter) {
+    const oauthSessionId = entry.key[1] as string;
+    promises.push(deleteOAuthSession(oauthSessionId));
+  }
+  for await (const entry of tokensIter) {
+    const sessionId = entry.key[1] as string;
+    promises.push(deleteStoredTokensBySession(sessionId));
+  }
+  await Promise.all(promises);
+}

--- a/src/clear_oauth_sessions_and_tokens_test.ts
+++ b/src/clear_oauth_sessions_and_tokens_test.ts
@@ -1,0 +1,33 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import {
+  getOAuthSession,
+  getTokensBySession,
+  setOAuthSession,
+  setTokensBySession,
+} from "./core.ts";
+import { clearOAuthSessionsAndTokens } from "./clear_oauth_sessions_and_tokens.ts";
+import { assertEquals, assertNotEquals } from "../dev_deps.ts";
+
+Deno.test("clearOAuthSessionsAndTokens()", async () => {
+  const ids = Array.from({ length: 10 }).map(() => crypto.randomUUID());
+
+  for (const id of ids) {
+    await setOAuthSession(id, {
+      state: crypto.randomUUID(),
+      codeVerifier: crypto.randomUUID(),
+    });
+    assertNotEquals(await getOAuthSession(id), null);
+    await setTokensBySession(id, {
+      accessToken: crypto.randomUUID(),
+      tokenType: crypto.randomUUID(),
+    });
+    assertNotEquals(await getTokensBySession(id), null);
+  }
+
+  await clearOAuthSessionsAndTokens();
+
+  for (const id of ids) {
+    assertEquals(await getOAuthSession(id), null);
+    assertEquals(await getTokensBySession(id), null);
+  }
+});

--- a/src/core.ts
+++ b/src/core.ts
@@ -55,6 +55,11 @@ export async function getOAuthSession(oauthSessionId: string) {
   return result.value;
 }
 
+// Lists all OAuth 2.0 session entries.
+export function listOAuthSessions() {
+  return kv.list<OAuthSession>({ prefix: [OAUTH_SESSION_PREFIX] });
+}
+
 // Stores the OAuth 2.0 session object for the given OAuth 2.0 session ID.
 export async function setOAuthSession(
   oauthSessionId: string,
@@ -122,6 +127,11 @@ export async function getTokensBySession(
     sessionId,
   ], { consistency });
   return result.value !== null ? toTokens(result.value) : null;
+}
+
+// Lists all tokens entries.
+export function listTokens() {
+  return kv.list<Tokens>({ prefix: [STORED_TOKENS_BY_SESSION_PREFIX] });
 }
 
 /**


### PR DESCRIPTION
Even once key expiration comes to Deno KV, there will be instances where KV entries will need to be deleted. E.g. migrations.

Supersedes #151