### PR TITLE
chore: add `--trace-ops` to `test` task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
     "check:license": "deno run -A tools/check_license.ts --check",
     "check:types": "deno check --unstable **/*.ts",
     "check": "deno task check:license && deno task check:types",
-    "test": "KV_PATH=:memory: deno test --unstable --allow-env --allow-read --allow-run --parallel --doc --coverage=./cov",
+    "test": "KV_PATH=:memory: deno test --unstable --allow-env --allow-read --allow-run --parallel --doc --trace-ops --coverage=./cov",
     "ok": "deno fmt --check && deno lint && deno task check && deno task test",
     "cov": "deno coverage ./cov/ --lcov --exclude='test.ts|testdata' > cov.lcov",
     "update": "deno run -A https://deno.land/x/udd/main.ts --test=\"deno task test\" deps.ts dev_deps.ts"


### PR DESCRIPTION
This will provide further context for when tests fail. Thought I'd add this due to https://github.com/denoland/deno_kv_oauth/actions/runs/5970246683/job/16197528484