### PR TITLE
feat: OAuth session expiry

### DIFF
--- a/demo_test.ts
+++ b/demo_test.ts
@@ -8,7 +8,7 @@ import {
   isRedirectStatus,
 } from "./dev_deps.ts";
 import { Status } from "./deps.ts";
-import { setTokensBySession, SITE_COOKIE_NAME } from "./src/core.ts";
+import { setTokens, SITE_COOKIE_NAME } from "./src/core.ts";
 
 const baseUrl = "http://localhost";
 
@@ -34,7 +34,7 @@ Deno.test("demo", async (test) => {
   await test.step("GET / serves a signed-in web page", async () => {
     const sessionId = crypto.randomUUID();
     const accessToken = crypto.randomUUID();
-    await setTokensBySession(sessionId, {
+    await setTokens(sessionId, {
       accessToken,
       tokenType: crypto.randomUUID(),
     });

--- a/src/clear_oauth_sessions_and_tokens_test.ts
+++ b/src/clear_oauth_sessions_and_tokens_test.ts
@@ -1,9 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import {
+  getLegacyTokens,
   getOAuthSession,
-  getTokensBySession,
+  getTokens,
+  setLegacyTokens,
   setOAuthSession,
-  setTokensBySession,
+  setTokens,
 } from "./core.ts";
 import { clearOAuthSessionsAndTokens } from "./clear_oauth_sessions_and_tokens.ts";
 import { assertEquals, assertNotEquals } from "../dev_deps.ts";
@@ -17,17 +19,20 @@ Deno.test("clearOAuthSessionsAndTokens()", async () => {
       codeVerifier: crypto.randomUUID(),
     });
     assertNotEquals(await getOAuthSession(id), null);
-    await setTokensBySession(id, {
+    await setLegacyTokens(id, crypto.randomUUID());
+    assertNotEquals(await getLegacyTokens(id), null);
+    await setTokens(id, {
       accessToken: crypto.randomUUID(),
       tokenType: crypto.randomUUID(),
     });
-    assertNotEquals(await getTokensBySession(id), null);
+    assertNotEquals(await getTokens(id), null);
   }
 
   await clearOAuthSessionsAndTokens();
 
   for (const id of ids) {
     assertEquals(await getOAuthSession(id), null);
-    assertEquals(await getTokensBySession(id), null);
+    assertEquals(await getLegacyTokens(id), null);
+    assertEquals(await getTokens(id), null);
   }
 });

--- a/src/core.ts
+++ b/src/core.ts
@@ -58,12 +58,8 @@ export function listOAuthSessions() {
 }
 
 // Stores the OAuth 2.0 session object for the given OAuth 2.0 session ID.
-export async function setOAuthSession(
-  id: string,
-  value: OAuthSession,
-  expireIn?: number,
-) {
-  await kv.set([OAUTH_SESSIONS_PREFIX, id], value, { expireIn });
+export async function setOAuthSession(id: string, value: OAuthSession) {
+  await kv.set([OAUTH_SESSIONS_PREFIX, id], value);
 }
 
 // Deletes the OAuth 2.0 session object for the given OAuth 2.0 session ID.

--- a/src/core.ts
+++ b/src/core.ts
@@ -58,8 +58,12 @@ export function listOAuthSessions() {
 }
 
 // Stores the OAuth 2.0 session object for the given OAuth 2.0 session ID.
-export async function setOAuthSession(id: string, value: OAuthSession) {
-  await kv.set([OAUTH_SESSIONS_PREFIX, id], value);
+export async function setOAuthSession(
+  id: string,
+  value: OAuthSession,
+  expireIn?: number,
+) {
+  await kv.set([OAUTH_SESSIONS_PREFIX, id], value, { expireIn });
 }
 
 // Deletes the OAuth 2.0 session object for the given OAuth 2.0 session ID.

--- a/src/core_test.ts
+++ b/src/core_test.ts
@@ -2,15 +2,15 @@
 import { assert, assertEquals, Status, type Tokens } from "../dev_deps.ts";
 import {
   deleteOAuthSession,
-  deleteStoredTokensBySession,
+  deleteTokens,
   getCookieName,
   getOAuthSession,
-  getTokensBySession,
+  getTokens,
   isSecure,
   type OAuthSession,
   redirect,
   setOAuthSession,
-  setTokensBySession,
+  setTokens,
   toStoredTokens,
   toTokens,
 } from "./core.ts";
@@ -36,11 +36,9 @@ Deno.test("(get/set/delete)OAuthSession() work interchangeably", async () => {
     codeVerifier: crypto.randomUUID(),
   };
   await setOAuthSession(id, oauthSession);
-
   assertEquals(await getOAuthSession(id), oauthSession);
 
   await deleteOAuthSession(id);
-
   assertEquals(await getOAuthSession(id), null);
 });
 
@@ -56,23 +54,21 @@ Deno.test("toStoredTokens() + toTokens() work interchangeably", () => {
   assert(currentTokens.expiresIn! < initialTokens.expiresIn!);
 });
 
-Deno.test("(get/set/delete)TokensBySession() work interchangeably", async () => {
+Deno.test("(get/set/delete)Tokens() work interchangeably", async () => {
   const sessionId = crypto.randomUUID();
 
   // Tokens don't yet exist
-  assertEquals(await getTokensBySession(sessionId), null);
+  assertEquals(await getTokens(sessionId), null);
 
   const tokens: Tokens = {
     accessToken: crypto.randomUUID(),
     tokenType: crypto.randomUUID(),
   };
-  await setTokensBySession(sessionId, tokens);
+  await setTokens(sessionId, tokens);
+  assertEquals(await getTokens(sessionId), tokens);
 
-  assertEquals(await getTokensBySession(sessionId), tokens);
-
-  await deleteStoredTokensBySession(sessionId);
-
-  assertEquals(await getTokensBySession(sessionId), null);
+  await deleteTokens(sessionId);
+  assertEquals(await getTokens(sessionId), null);
 });
 
 Deno.test("redirect() returns a redirect response", () => {

--- a/src/get_session_access_token.ts
+++ b/src/get_session_access_token.ts
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { OAuth2Client, OAuth2ResponseError, SECOND, Tokens } from "../deps.ts";
-import { getTokensBySession, setTokensBySession } from "./core.ts";
+import { getTokens, setTokens } from "./core.ts";
 
 /**
  * Gets the access token for a given OAuth 2.0 client and session. If null is returned, the client must sign in.
@@ -24,8 +24,8 @@ export async function getSessionAccessToken(
   sessionId: string,
 ) {
   // First, try with eventual consistency. If that returns null, try with strong consistency.
-  const tokens = await getTokensBySession(sessionId, "eventual") ||
-    await getTokensBySession(sessionId);
+  const tokens = await getTokens(sessionId, "eventual") ||
+    await getTokens(sessionId);
   if (tokens === null) return null;
   if (
     tokens.refreshToken === undefined ||
@@ -49,7 +49,7 @@ export async function getSessionAccessToken(
     throw error;
   }
 
-  await setTokensBySession(sessionId, newTokens);
+  await setTokens(sessionId, newTokens);
 
   return newTokens.accessToken;
 }

--- a/src/get_session_access_token_test.ts
+++ b/src/get_session_access_token_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { getSessionAccessToken } from "./get_session_access_token.ts";
 import { assertEquals, assertRejects, SECOND, Tokens } from "../dev_deps.ts";
-import { setTokensBySession } from "./core.ts";
+import { setTokens } from "./core.ts";
 import { oauth2Client } from "./test_utils.ts";
 
 Deno.test("getSessionAccessToken()", async (test) => {
@@ -15,7 +15,7 @@ Deno.test("getSessionAccessToken()", async (test) => {
       accessToken: crypto.randomUUID(),
       tokenType: "Bearer",
     };
-    await setTokensBySession(sessionId, tokens);
+    await setTokens(sessionId, tokens);
     assertEquals(
       await getSessionAccessToken(oauth2Client, sessionId),
       tokens.accessToken,
@@ -30,7 +30,7 @@ Deno.test("getSessionAccessToken()", async (test) => {
       expiresIn: Date.now() + (30 * SECOND),
       refreshToken: crypto.randomUUID(),
     };
-    await setTokensBySession(sessionId, tokens);
+    await setTokens(sessionId, tokens);
     assertEquals(
       await getSessionAccessToken(oauth2Client, sessionId),
       tokens.accessToken,
@@ -45,7 +45,7 @@ Deno.test("getSessionAccessToken()", async (test) => {
       expiresIn: 0,
       refreshToken: crypto.randomUUID(),
     };
-    await setTokensBySession(sessionId, tokens);
+    await setTokens(sessionId, tokens);
     assertRejects(async () =>
       await getSessionAccessToken(oauth2Client, sessionId)
     );
@@ -59,7 +59,7 @@ Deno.test("getSessionAccessToken()", async (test) => {
       expiresIn: 60,
       refreshToken: crypto.randomUUID(),
     };
-    await setTokensBySession(sessionId, tokens);
+    await setTokens(sessionId, tokens);
     assertRejects(async () =>
       await getSessionAccessToken(oauth2Client, sessionId)
     );

--- a/src/handle_callback.ts
+++ b/src/handle_callback.ts
@@ -8,7 +8,7 @@ import {
   isSecure,
   OAUTH_COOKIE_NAME,
   redirect,
-  setTokensBySession,
+  setTokens,
   SITE_COOKIE_NAME,
 } from "./core.ts";
 
@@ -67,7 +67,7 @@ export async function handleCallback(
   );
 
   const sessionId = crypto.randomUUID();
-  await setTokensBySession(sessionId, tokens);
+  await setTokens(sessionId, tokens);
 
   const response = redirect(redirectUrl);
   setCookie(

--- a/src/sign_out.ts
+++ b/src/sign_out.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { deleteCookie } from "../deps.ts";
 import {
-  deleteStoredTokensBySession,
+  deleteTokens,
   getCookieName,
   isSecure,
   redirect,
@@ -32,7 +32,7 @@ export async function signOut(request: Request, redirectUrl = "/") {
   const sessionId = getSessionId(request);
   if (sessionId === undefined) return redirect(redirectUrl);
 
-  await deleteStoredTokensBySession(sessionId);
+  await deleteTokens(sessionId);
 
   const response = redirect(redirectUrl);
   const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));

--- a/src/sign_out_test.ts
+++ b/src/sign_out_test.ts
@@ -1,11 +1,7 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, Status, type Tokens } from "../dev_deps.ts";
 import { signOut } from "./sign_out.ts";
-import {
-  getTokensBySession,
-  setTokensBySession,
-  SITE_COOKIE_NAME,
-} from "./core.ts";
+import { getTokens, setTokens, SITE_COOKIE_NAME } from "./core.ts";
 
 Deno.test("signOut()", async (test) => {
   const sessionId = crypto.randomUUID();
@@ -13,7 +9,7 @@ Deno.test("signOut()", async (test) => {
     accessToken: crypto.randomUUID(),
     tokenType: crypto.randomUUID(),
   };
-  await setTokensBySession(sessionId, tokens);
+  await setTokens(sessionId, tokens);
   const redirectUrl = "/why-hello-there";
   const request = new Request("http://example.com", {
     headers: {
@@ -36,6 +32,6 @@ Deno.test("signOut()", async (test) => {
   });
 
   await test.step("deletes the tokens entry in KV", async () => {
-    assertEquals(await getTokensBySession(sessionId), null);
+    assertEquals(await getTokens(sessionId), null);
   });
 });


### PR DESCRIPTION
This change adds OAuth session expirations to Deno KV. This will automatically keep the `oauth-session` KV space clean by expiring entries after 10 minutes, on par with cookie expiration.

The same optimisation has not been applied to site sessions. This is because keeping site sessions, which include refresh tokens, allows the user's session to be automatically refreshed once the access token has expired. I believe this is the best balance between KV-space efficiency and user convenience.

Note: Deno Deploy is awaiting KV key expiration functionality.

Prerequisite #169
Supercedes #164
Closes #148