### PR TITLE
revert: Fresh plugin removal (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,48 @@ Github as the OAuth provider. Source code is located in [demo.ts](demo.ts).
 Check out the full documentation and API reference
 [here](https://doc.deno.land/https://deno.land/x/deno_kv_oauth/mod.ts).
 
-### Getting Started
+### Getting Started with [Fresh](https://fresh.deno.dev/)
 
-> Note: Fresh has a first party Plugin for Deno KV OAuth. Check out the
-> [Fresh](https://fresh.deno.dev/docs/examples/using-deno-kv-oauth)
-> documentation for more information.
+> Note: The minimum required version for plugins in Fresh is 1.3.0 If you're not
+> performing anything special in the sign-in, sign-out and callback handlers,
+> you can add the Fresh plugin to your project. This automatically handles
+> `GET /oauth/signin`, `GET /oauth/callback` and `GET /oauth/signout` routes.
+
+1. Create your OAuth 2.0 application for your given provider.
+
+1. Create your [pre-defined](#pre-defined-oauth-configurations) or
+   [custom](#custom-oauth-configuration) OAuth configuration and configure Fresh
+   to use the plugin.
+
+   ```ts
+   // main.ts
+   import { start } from "$fresh/server.ts";
+   import {
+     createGithubOAuthConfig,
+     kvOAuthPlugin,
+   } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+   import manifest from "./fresh.gen.ts";
+
+   await start(manifest, {
+     plugins: [
+       kvOAuthPlugin(createGithubOAuthConfig()),
+     ],
+   });
+   ```
+
+If you require more advanced setups, you can create your own plugin. For more
+information, see:
+
+- The [source code](src/fresh_plugin.ts) for `kvOAuthPlugin()`
+- The [Plugin documentation](https://fresh.deno.dev/docs/concepts/plugins) for
+  Fresh
+- The
+  [Fresh + Deno KV OAuth demo](https://github.com/denoland/fresh-deno-kv-oauth-demo)
+  which uses the Fresh plugin
+- [Deno SaaSKit](https://saaskit.deno.dev/)'s custom
+  [plugin implementation](https://github.com/denoland/saaskit/blob/3accffdc44c2d2eb6dba28126f8d4cb525eba340/plugins/kv_oauth.ts)
+
+### Getting Started with Other Frameworks
 
 This example uses GitHub as the OAuth provider. However, you can use any
 provider you like.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,11 @@
 {
   "lock": false,
   "imports": {
-    "https://deno.land/x/deno_kv_oauth@$VERSION/": "./"
+    "https://deno.land/x/deno_kv_oauth@$VERSION/": "./",
+    "$fresh/": "https://deno.land/x/fresh@1.4.2/",
+    "preact": "https://esm.sh/preact@10.15.1",
+    "preact/": "https://esm.sh/preact@10.15.1/",
+    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.1"
   },
   "tasks": {
     "demo": "deno run --allow-net --allow-env --allow-read --unstable --watch=demo.ts,mod.ts demo.ts",

--- a/lib/fresh_plugin.ts
+++ b/lib/fresh_plugin.ts
@@ -1,0 +1,73 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import type { Plugin } from "$fresh/server.ts";
+import type { OAuth2ClientConfig } from "../deps.ts";
+import { signIn } from "./sign_in.ts";
+import { handleCallback } from "./handle_callback.ts";
+import { signOut } from "./sign_out.ts";
+
+/**
+ * Creates a basic plugin for the [Fresh]{@link https://fresh.deno.dev/} web framework.
+ *
+ * This creates handlers for the following routes:
+ * - `GET /oauth/signin` for the sign-in page
+ * - `GET /oauth/callback` for the callback page
+ * - `GET /oauth/signout` for the sign-out page
+ *
+ * ```ts
+ * // main.ts
+ * import { start } from "$fresh/server.ts";
+ * import { createGitHubOAuthConfig, kvOAuthPlugin } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+ * import manifest from "./fresh.gen.ts";
+ *
+ * await start(manifest, {
+ *   plugins: [
+ *     kvOAuthPlugin(createGitHubOAuthConfig())
+ *   ]
+ * });
+ * ```
+ */
+export function kvOAuthPlugin(
+  oauthConfig: OAuth2ClientConfig,
+  options?: {
+    /**
+     * Sign-in page path
+     *
+     * @default {"/oauth/signin"}
+     */
+    signInPath?: string;
+    /**
+     * Callback page path
+     *
+     * @default {"/oauth/callback"}
+     */
+    callbackPath?: string;
+    /**
+     * Sign-out page path
+     *
+     * @default {"/oauth/signout"}
+     */
+    signOutPath?: string;
+  },
+): Plugin {
+  return {
+    name: "kv-oauth",
+    routes: [
+      {
+        path: options?.signInPath ?? "/oauth/signin",
+        handler: async (req) => await signIn(req, oauthConfig),
+      },
+      {
+        path: options?.callbackPath ?? "/oauth/callback",
+        handler: async (req) => {
+          // Return object also includes `accessToken` and `sessionId` properties.
+          const { response } = await handleCallback(req, oauthConfig);
+          return response;
+        },
+      },
+      {
+        path: options?.signOutPath ?? "/oauth/signout",
+        handler: signOut,
+      },
+    ],
+  };
+}

--- a/lib/fresh_plugin.ts
+++ b/lib/fresh_plugin.ts
@@ -5,6 +5,27 @@ import { signIn } from "./sign_in.ts";
 import { handleCallback } from "./handle_callback.ts";
 import { signOut } from "./sign_out.ts";
 
+export interface KvOAuthPluginOptions {
+  /**
+   * Sign-in page path
+   *
+   * @default {"/oauth/signin"}
+   */
+  signInPath?: string;
+  /**
+   * Callback page path
+   *
+   * @default {"/oauth/callback"}
+   */
+  callbackPath?: string;
+  /**
+   * Sign-out page path
+   *
+   * @default {"/oauth/signout"}
+   */
+  signOutPath?: string;
+}
+
 /**
  * Creates a basic plugin for the [Fresh]{@link https://fresh.deno.dev/} web framework.
  *
@@ -28,26 +49,7 @@ import { signOut } from "./sign_out.ts";
  */
 export function kvOAuthPlugin(
   oauthConfig: OAuth2ClientConfig,
-  options?: {
-    /**
-     * Sign-in page path
-     *
-     * @default {"/oauth/signin"}
-     */
-    signInPath?: string;
-    /**
-     * Callback page path
-     *
-     * @default {"/oauth/callback"}
-     */
-    callbackPath?: string;
-    /**
-     * Sign-out page path
-     *
-     * @default {"/oauth/signout"}
-     */
-    signOutPath?: string;
-  },
+  options?: KvOAuthPluginOptions,
 ): Plugin {
   return {
     name: "kv-oauth",

--- a/lib/fresh_plugin_test.ts
+++ b/lib/fresh_plugin_test.ts
@@ -1,0 +1,33 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+import { kvOAuthPlugin } from "./fresh_plugin.ts";
+import { assert, assertArrayIncludes, assertNotEquals } from "../dev_deps.ts";
+import { randomOAuthConfig } from "./_test_utils.ts";
+
+Deno.test("kvOAuthPlugin() works with default values", () => {
+  const plugin = kvOAuthPlugin(randomOAuthConfig());
+  assertNotEquals(plugin.routes, undefined);
+  assert(plugin.routes!.every((route) => route.handler !== undefined));
+  assertArrayIncludes(plugin.routes!.map((route) => route.path), [
+    "/oauth/signin",
+    "/oauth/callback",
+    "/oauth/signout",
+  ]);
+});
+
+Deno.test("kvOAuthPlugin() works with defined values", () => {
+  const signInPath = "/signin";
+  const callbackPath = "/callback";
+  const signOutPath = "/signout";
+  const plugin = kvOAuthPlugin(randomOAuthConfig(), {
+    signInPath,
+    callbackPath,
+    signOutPath,
+  });
+  assertNotEquals(plugin.routes, undefined);
+  assert(plugin.routes!.every((route) => route.handler !== undefined));
+  assertArrayIncludes(plugin.routes!.map((route) => route.path), [
+    signInPath,
+    callbackPath,
+    signOutPath,
+  ]);
+});

--- a/mod.ts
+++ b/mod.ts
@@ -18,3 +18,4 @@ export * from "./lib/create_patreon_oauth_config.ts";
 export * from "./lib/create_slack_oauth_config.ts";
 export * from "./lib/create_spotify_oauth_config.ts";
 export * from "./lib/create_twitter_oauth_config.ts";
+export * from "./lib/fresh_plugin.ts";


### PR DESCRIPTION
This change adds the Fresh plugin back to this module. Frankly, #192 was merged prematurely (my bad). This allows us to cut a release with some important updates without waiting for Fresh's next release. This plugin will be removed upon Fresh's new release, which will be the new home for the Deno KV OAuth Fresh plugin. A few small notable changes:
1. No `/fresh.ts` - just import from `/lib/fresh_plugin.ts`
2. It's been updated to use `OAuth2ClientConfig` instead of `OAuth2Client`, like the rest of the codebase