### PR TITLE
feat: export `OAuth2ClientConfig` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ configurations.
    import {
      getRequiredEnv,
      handleCallback,
+     type OAuth2ClientConfig,
      signIn,
      signOut,
    } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
-   import type { OAuth2ClientConfig } from "https://deno.land/x/oauth2_client/mod.ts";
 
    const oauthConfig: OAuth2ClientConfig = {
      clientId: getRequiredEnv("CUSTOM_CLIENT_ID"),

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -2,7 +2,7 @@
 import {
   getCookies,
   OAuth2Client,
-  OAuth2ClientConfig,
+  type OAuth2ClientConfig,
   setCookie,
 } from "../deps.ts";
 import {

--- a/lib/sign_in.ts
+++ b/lib/sign_in.ts
@@ -2,7 +2,7 @@
 import {
   Cookie,
   OAuth2Client,
-  OAuth2ClientConfig,
+  type OAuth2ClientConfig,
   SECOND,
   setCookie,
 } from "../deps.ts";

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,2 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+export type { OAuth2ClientConfig } from "../deps.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -17,3 +17,4 @@ export * from "./lib/create_slack_oauth_config.ts";
 export * from "./lib/create_spotify_oauth_config.ts";
 export * from "./lib/create_twitter_oauth_config.ts";
 export * from "./lib/fresh_plugin.ts";
+export * from "./lib/types.ts";


### PR DESCRIPTION
This change removes the need to import `OAuth2ClientConfig` from the x/oauth2_client module.