### PR TITLE
feat: support OAuth flows across subdomains

### DIFF
--- a/lib/_http.ts
+++ b/lib/_http.ts
@@ -8,8 +8,8 @@ export const SITE_COOKIE_NAME = "site-session";
  * Determines whether the request URL is of a secure origin using the HTTPS
  * protocol.
  */
-export function isSecure(requestUrl: string) {
-  return new URL(requestUrl).protocol === "https:";
+export function isSecure(url: URL) {
+  return url.protocol === "https:";
 }
 
 /**
@@ -17,10 +17,17 @@ export function isSecure(requestUrl: string) {
  * origin (HTTPS).
  */
 export function getCookieName(name: string, isSecure: boolean) {
-  return isSecure ? "__Host-" + name : name;
+  return isSecure ? "__Secure-" + name : name;
 }
 
-/** @see {@link https://web.dev/first-party-cookie-recipes/#the-good-first-party-cookie-recipe} */
+export function getDomain(url: URL) {
+  return url.hostname
+    .split(".")
+    .slice(-2)
+    .join(".");
+}
+
+/** @see {@link https://web.dev/first-party-cookie-recipes/#first-party-cookie-recipe-for-sites-with-subdomains} */
 export const COOKIE_BASE = {
   path: "/",
   httpOnly: true,

--- a/lib/_http_test.ts
+++ b/lib/_http_test.ts
@@ -1,16 +1,26 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../dev_deps.ts";
-import { getCookieName, getSuccessUrl, isSecure, redirect } from "./_http.ts";
+import {
+  getCookieName,
+  getDomain,
+  getSuccessUrl,
+  isSecure,
+  redirect,
+} from "./_http.ts";
 import { assertRedirect } from "./_test_utils.ts";
 
 Deno.test("isSecure()", () => {
-  assertEquals(isSecure("https://example.com"), true);
-  assertEquals(isSecure("http://example.com"), false);
+  assertEquals(isSecure(new URL("https://example.com")), true);
+  assertEquals(isSecure(new URL("http://example.com")), false);
 });
 
 Deno.test("getCookieName()", () => {
-  assertEquals(getCookieName("hello", true), "__Host-hello");
+  assertEquals(getCookieName("hello", true), "__Secure-hello");
   assertEquals(getCookieName("hello", false), "hello");
+});
+
+Deno.test("getDomain()", () => {
+  assertEquals(getDomain(new URL("https://finance.news.site/")), "news.site");
 });
 
 Deno.test("redirect() returns a redirect response", () => {

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -24,6 +24,7 @@ import { getCookieName, isSecure, SITE_COOKIE_NAME } from "./_http.ts";
  * ```
  */
 export function getSessionId(request: Request) {
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
+  const url = new URL(request.url);
+  const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(url));
   return getCookies(request.headers)[cookieName] as string | undefined;
 }

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -8,6 +8,7 @@ import {
 import {
   COOKIE_BASE,
   getCookieName,
+  getDomain,
   isSecure,
   OAUTH_COOKIE_NAME,
   redirect,
@@ -56,9 +57,10 @@ export async function handleCallback(
   /** @see {@linkcode OAuth2ClientConfig} */
   oauthConfig: OAuth2ClientConfig,
 ) {
+  const url = new URL(request.url);
   const oauthCookieName = getCookieName(
     OAUTH_COOKIE_NAME,
-    isSecure(request.url),
+    isSecure(url),
   );
   const oauthSessionId = getCookies(request.headers)[oauthCookieName];
   if (oauthSessionId === undefined) throw new Error("OAuth cookie not found");
@@ -74,9 +76,10 @@ export async function handleCallback(
     response.headers,
     {
       ...COOKIE_BASE,
-      name: getCookieName(SITE_COOKIE_NAME, isSecure(request.url)),
+      name: getCookieName(SITE_COOKIE_NAME, isSecure(url)),
       value: sessionId,
-      secure: isSecure(request.url),
+      secure: isSecure(url),
+      domain: getDomain(url),
     },
   );
   return {

--- a/lib/sign_in.ts
+++ b/lib/sign_in.ts
@@ -9,6 +9,7 @@ import {
 import {
   COOKIE_BASE,
   getCookieName,
+  getDomain,
   getSuccessUrl,
   isSecure,
   OAUTH_COOKIE_NAME,
@@ -65,12 +66,14 @@ export async function signIn(
     );
   }
 
+  const url = new URL(request.url);
   const oauthSessionId = crypto.randomUUID();
   const cookie: Cookie = {
     ...COOKIE_BASE,
-    name: getCookieName(OAUTH_COOKIE_NAME, isSecure(request.url)),
+    name: getCookieName(OAUTH_COOKIE_NAME, isSecure(url)),
     value: oauthSessionId,
-    secure: isSecure(request.url),
+    secure: isSecure(url),
+    domain: getDomain(url),
     /**
      * A maximum authorization code lifetime of 10 minutes is recommended.
      * This cookie lifetime matches that value.

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -37,8 +37,9 @@ export function signOut(request: Request) {
   const successUrl = getSuccessUrl(request);
   if (sessionId === undefined) return redirect(successUrl);
 
+  const url = new URL(request.url);
   const response = redirect(successUrl);
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
+  const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(url));
   deleteCookie(response.headers, cookieName, { path: "/" });
   return response;
 }


### PR DESCRIPTION
This change loosens the base cookie recipe to support cookies within the same domain, regardless of the sub-domain. This is more flexible yet still reasonably secure.

Closes #202