### PR TITLE
refactor: rename `isSecure()` to `isHttps()`

### DIFF
--- a/lib/_http.ts
+++ b/lib/_http.ts
@@ -8,16 +8,16 @@ export const SITE_COOKIE_NAME = "site-session";
  * Determines whether the request URL is of a secure origin using the HTTPS
  * protocol.
  */
-export function isSecure(requestUrl: string) {
-  return new URL(requestUrl).protocol === "https:";
+export function isHttps(url: URL) {
+  return url.protocol === "https:";
 }
 
 /**
  * Dynamically prefixes the cookie name, depending on whether it's for a secure
  * origin (HTTPS).
  */
-export function getCookieName(name: string, isSecure: boolean) {
-  return isSecure ? "__Host-" + name : name;
+export function getCookieName(name: string, isHttps: boolean) {
+  return isHttps ? "__Host-" + name : name;
 }
 
 /** @see {@link https://web.dev/first-party-cookie-recipes/#the-good-first-party-cookie-recipe} */

--- a/lib/_http.ts
+++ b/lib/_http.ts
@@ -8,8 +8,8 @@ export const SITE_COOKIE_NAME = "site-session";
  * Determines whether the request URL is of a secure origin using the HTTPS
  * protocol.
  */
-export function isHttps(url: URL) {
-  return url.protocol === "https:";
+export function isHttps(url: string) {
+  return url.startsWith("https://");
 }
 
 /**

--- a/lib/_http_test.ts
+++ b/lib/_http_test.ts
@@ -1,11 +1,11 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "../dev_deps.ts";
-import { getCookieName, getSuccessUrl, isSecure, redirect } from "./_http.ts";
+import { getCookieName, getSuccessUrl, isHttps, redirect } from "./_http.ts";
 import { assertRedirect } from "./_test_utils.ts";
 
-Deno.test("isSecure()", () => {
-  assertEquals(isSecure("https://example.com"), true);
-  assertEquals(isSecure("http://example.com"), false);
+Deno.test("isHttps()", () => {
+  assertEquals(isHttps(new URL("https://example.com")), true);
+  assertEquals(isHttps(new URL("http://example.com")), false);
 });
 
 Deno.test("getCookieName()", () => {

--- a/lib/_http_test.ts
+++ b/lib/_http_test.ts
@@ -4,8 +4,8 @@ import { getCookieName, getSuccessUrl, isHttps, redirect } from "./_http.ts";
 import { assertRedirect } from "./_test_utils.ts";
 
 Deno.test("isHttps()", () => {
-  assertEquals(isHttps(new URL("https://example.com")), true);
-  assertEquals(isHttps(new URL("http://example.com")), false);
+  assertEquals(isHttps("https://example.com"), true);
+  assertEquals(isHttps("http://example.com"), false);
 });
 
 Deno.test("getCookieName()", () => {

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { getCookies } from "../deps.ts";
-import { getCookieName, isSecure, SITE_COOKIE_NAME } from "./_http.ts";
+import { getCookieName, isHttps, SITE_COOKIE_NAME } from "./_http.ts";
 
 /**
  * Gets the session ID for a given request. This is well-suited for checking
@@ -24,6 +24,7 @@ import { getCookieName, isSecure, SITE_COOKIE_NAME } from "./_http.ts";
  * ```
  */
 export function getSessionId(request: Request) {
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
+  const url = new URL(request.url);
+  const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(url));
   return getCookies(request.headers)[cookieName] as string | undefined;
 }

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -24,7 +24,6 @@ import { getCookieName, isHttps, SITE_COOKIE_NAME } from "./_http.ts";
  * ```
  */
 export function getSessionId(request: Request) {
-  const url = new URL(request.url);
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(url));
+  const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
   return getCookies(request.headers)[cookieName] as string | undefined;
 }

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -56,10 +56,9 @@ export async function handleCallback(
   /** @see {@linkcode OAuth2ClientConfig} */
   oauthConfig: OAuth2ClientConfig,
 ) {
-  const url = new URL(request.url);
   const oauthCookieName = getCookieName(
     OAUTH_COOKIE_NAME,
-    isHttps(url),
+    isHttps(request.url),
   );
   const oauthSessionId = getCookies(request.headers)[oauthCookieName];
   if (oauthSessionId === undefined) throw new Error("OAuth cookie not found");
@@ -75,9 +74,9 @@ export async function handleCallback(
     response.headers,
     {
       ...COOKIE_BASE,
-      name: getCookieName(SITE_COOKIE_NAME, isHttps(url)),
+      name: getCookieName(SITE_COOKIE_NAME, isHttps(request.url)),
       value: sessionId,
-      secure: isHttps(url),
+      secure: isHttps(request.url),
     },
   );
   return {

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -8,7 +8,7 @@ import {
 import {
   COOKIE_BASE,
   getCookieName,
-  isSecure,
+  isHttps,
   OAUTH_COOKIE_NAME,
   redirect,
   SITE_COOKIE_NAME,
@@ -56,9 +56,10 @@ export async function handleCallback(
   /** @see {@linkcode OAuth2ClientConfig} */
   oauthConfig: OAuth2ClientConfig,
 ) {
+  const url = new URL(request.url);
   const oauthCookieName = getCookieName(
     OAUTH_COOKIE_NAME,
-    isSecure(request.url),
+    isHttps(url),
   );
   const oauthSessionId = getCookies(request.headers)[oauthCookieName];
   if (oauthSessionId === undefined) throw new Error("OAuth cookie not found");
@@ -74,9 +75,9 @@ export async function handleCallback(
     response.headers,
     {
       ...COOKIE_BASE,
-      name: getCookieName(SITE_COOKIE_NAME, isSecure(request.url)),
+      name: getCookieName(SITE_COOKIE_NAME, isHttps(url)),
       value: sessionId,
-      secure: isSecure(request.url),
+      secure: isHttps(url),
     },
   );
   return {

--- a/lib/sign_in.ts
+++ b/lib/sign_in.ts
@@ -65,13 +65,12 @@ export async function signIn(
     );
   }
 
-  const url = new URL(request.url);
   const oauthSessionId = crypto.randomUUID();
   const cookie: Cookie = {
     ...COOKIE_BASE,
-    name: getCookieName(OAUTH_COOKIE_NAME, isHttps(url)),
+    name: getCookieName(OAUTH_COOKIE_NAME, isHttps(request.url)),
     value: oauthSessionId,
-    secure: isHttps(url),
+    secure: isHttps(request.url),
     /**
      * A maximum authorization code lifetime of 10 minutes is recommended.
      * This cookie lifetime matches that value.

--- a/lib/sign_in.ts
+++ b/lib/sign_in.ts
@@ -10,7 +10,7 @@ import {
   COOKIE_BASE,
   getCookieName,
   getSuccessUrl,
-  isSecure,
+  isHttps,
   OAUTH_COOKIE_NAME,
   redirect,
 } from "./_http.ts";
@@ -65,12 +65,13 @@ export async function signIn(
     );
   }
 
+  const url = new URL(request.url);
   const oauthSessionId = crypto.randomUUID();
   const cookie: Cookie = {
     ...COOKIE_BASE,
-    name: getCookieName(OAUTH_COOKIE_NAME, isSecure(request.url)),
+    name: getCookieName(OAUTH_COOKIE_NAME, isHttps(url)),
     value: oauthSessionId,
-    secure: isSecure(request.url),
+    secure: isHttps(url),
     /**
      * A maximum authorization code lifetime of 10 minutes is recommended.
      * This cookie lifetime matches that value.

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -39,8 +39,7 @@ export function signOut(request: Request) {
 
   const response = redirect(successUrl);
 
-  const url = new URL(request.url);
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(url));
+  const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
   deleteCookie(response.headers, cookieName, { path: "/" });
   return response;
 }

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -3,7 +3,7 @@ import { deleteCookie } from "../deps.ts";
 import {
   getCookieName,
   getSuccessUrl,
-  isSecure,
+  isHttps,
   redirect,
   SITE_COOKIE_NAME,
 } from "./_http.ts";
@@ -38,7 +38,9 @@ export function signOut(request: Request) {
   if (sessionId === undefined) return redirect(successUrl);
 
   const response = redirect(successUrl);
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isSecure(request.url));
+
+  const url = new URL(request.url);
+  const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(url));
   deleteCookie(response.headers, cookieName, { path: "/" });
   return response;
 }


### PR DESCRIPTION
This name is clearer. This also simplifies the logic. It's safe to assume the input is indeed a URL string.