### PR TITLE
refactor: remove unnecessary cookie check from `signOut()`

### DIFF
--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -1,13 +1,13 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { deleteCookie } from "../deps.ts";
 import {
+  COOKIE_BASE,
   getCookieName,
   getSuccessUrl,
   isHttps,
   redirect,
   SITE_COOKIE_NAME,
 } from "./_http.ts";
-import { getSessionId } from "./get_session_id.ts";
 
 /**
  * Handles the sign-out process, and then redirects the client to the given
@@ -25,13 +25,10 @@ import { getSessionId } from "./get_session_id.ts";
  * ```
  */
 export function signOut(request: Request) {
-  const sessionId = getSessionId(request);
   const successUrl = getSuccessUrl(request);
-  if (sessionId === undefined) return redirect(successUrl);
-
   const response = redirect(successUrl);
 
   const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
-  deleteCookie(response.headers, cookieName, { path: "/" });
+  deleteCookie(response.headers, cookieName, { path: COOKIE_BASE.path });
   return response;
 }

--- a/lib/sign_out_test.ts
+++ b/lib/sign_out_test.ts
@@ -11,11 +11,7 @@ Deno.test("signOut() returns a redirect response if the user is not signed-in", 
 });
 
 Deno.test("signOut() returns a response that signs out the signed-in user", async () => {
-  const sessionId = crypto.randomUUID();
-  const request = new Request(
-    "http://example.com/signout",
-    { headers: { cookie: `${SITE_COOKIE_NAME}=${sessionId}` } },
-  );
+  const request = new Request("http://example.com/signout");
   const response = await signOut(request);
   assertRedirect(response);
   assertEquals(


### PR DESCRIPTION
Previously, this check was justified because it could potentially avoid a database call. Now that the database call is gone, the check can be removed.