### PR TITLE
fix: make `cookieOptions` partial for `signOut()`

### DIFF
--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -11,7 +11,7 @@ import {
 
 export interface SignOutOptions {
   /** Overwrites cookie properties set in the response */
-  cookieOptions: Pick<Cookie, "name" | "path" | "domain">;
+  cookieOptions: Partial<Pick<Cookie, "name" | "path" | "domain">>;
 }
 
 /**


### PR DESCRIPTION
This change makes all chosen `cookieOptions` properties optional.