### PR TITLE
fix: clarify ability to define cookie name

### DIFF
--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -33,7 +33,8 @@ export function signOut(request: Request, options?: SignOutOptions) {
   const successUrl = getSuccessUrl(request);
   const response = redirect(successUrl);
 
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
+  const cookieName = options?.cookieOptions?.name ??
+    getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
   deleteCookie(response.headers, cookieName, {
     path: COOKIE_BASE.path,
     ...options?.cookieOptions,


### PR DESCRIPTION
The ability to define the cookie name using `options?.cookieOptions?.name` was already there. However, this makes it clear that that is the case.