### PR TITLE
feat: add `Client` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,22 +187,14 @@ This is required for OAuth solutions that span more than one sub-domain.
      const { pathname } = new URL(request.url);
      switch (pathname) {
        case "/oauth/signin":
-         return await kvOAuthClient.signIn(request, oauthConfig);
+         return await kvOAuthClient.signIn(request);
        case "/oauth/callback":
-         const { response } = await kvOAuthClient.handleCallback(
-           request,
-           oauthConfig,
-           {
-             cookieOptions,
-           },
-         );
+         const { response } = await kvOAuthClient.handleCallback(request);
          return response;
        case "/oauth/signout":
-         return kvOAuthClient.signOut(request, { cookieOptions });
+         return kvOAuthClient.signOut(request);
        case "/protected-route":
-         return kvOAuthClient.getSessionId(request, {
-             cookieName: cookieOptions.name,
-           }) ===
+         return kvOAuthClient.getSessionId(request) ===
              undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");

--- a/README.md
+++ b/README.md
@@ -172,34 +172,37 @@ This is required for OAuth solutions that span more than one sub-domain.
    ```ts
    // server.ts
    import {
+     Client,
      createGitHubOAuthConfig,
-     getSessionId,
-     handleCallback,
-     signIn,
-     signOut,
    } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
 
-   const oauthConfig = createGitHubOAuthConfig();
-
-   const cookieOptions = {
-     name: "__Secure-triple-choc",
-     domain: "news.site",
-   };
+   const kvOAuthClient = new Client(createGitHubOAuthConfig(), {
+     cookieOptions: {
+       name: "__Secure-triple-choc",
+       domain: "news.site",
+     },
+   });
 
    async function handler(request: Request) {
      const { pathname } = new URL(request.url);
      switch (pathname) {
        case "/oauth/signin":
-         return await signIn(request, oauthConfig);
+         return await kvOAuthClient.signIn(request, oauthConfig);
        case "/oauth/callback":
-         const { response } = await handleCallback(request, oauthConfig, {
-           cookieOptions,
-         });
+         const { response } = await kvOAuthClient.handleCallback(
+           request,
+           oauthConfig,
+           {
+             cookieOptions,
+           },
+         );
          return response;
        case "/oauth/signout":
-         return signOut(request, { cookieOptions });
+         return kvOAuthClient.signOut(request, { cookieOptions });
        case "/protected-route":
-         return getSessionId(request, { cookieName: cookieOptions.name }) ===
+         return kvOAuthClient.getSessionId(request, {
+             cookieName: cookieOptions.name,
+           }) ===
              undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,3 +1,4 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { signIn, type SignInOptions } from "./sign_in.ts";
 import { handleCallback } from "./handle_callback.ts";
 import { signOut } from "./sign_out.ts";

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,0 +1,34 @@
+import { signIn, type SignInOptions } from "./sign_in.ts";
+import { handleCallback } from "./handle_callback.ts";
+import { signOut } from "./sign_out.ts";
+import type { Cookie, OAuth2ClientConfig } from "../deps.ts";
+
+export interface ClientOptions {
+  cookieOptions?: Partial<Cookie>;
+}
+
+export class Client {
+  oauthConfig: OAuth2ClientConfig;
+  options?: ClientOptions;
+
+  constructor(oauthConfig: OAuth2ClientConfig, options?: ClientOptions) {
+    this.oauthConfig = oauthConfig;
+    this.options = options;
+  }
+
+  async signIn(request: Request, options?: SignInOptions) {
+    return await signIn(request, this.oauthConfig, options);
+  }
+
+  async handleCallback(request: Request) {
+    return await handleCallback(request, this.oauthConfig, {
+      cookieOptions: this.options?.cookieOptions,
+    });
+  }
+
+  async signOut(request: Request) {
+    return await signOut(request, {
+      cookieOptions: this.options?.cookieOptions,
+    });
+  }
+}

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -3,6 +3,7 @@ import { signIn, type SignInOptions } from "./sign_in.ts";
 import { handleCallback } from "./handle_callback.ts";
 import { signOut } from "./sign_out.ts";
 import type { Cookie, OAuth2ClientConfig } from "../deps.ts";
+import { getSessionId } from "./get_session_id.ts";
 
 export interface ClientOptions {
   cookieOptions?: Partial<Cookie>;
@@ -17,19 +18,111 @@ export class Client {
     this.options = options;
   }
 
+  /**
+   * Handles the sign-in request and process for the given OAuth configuration
+   * and redirects the client to the authorization URL.
+   *
+   * @see {@link https://deno.land/x/deno_kv_oauth#redirects-after-sign-in-and-sign-out}
+   *
+   * @example
+   * ```ts
+   * import {
+   *   Client,
+   *   createGitHubOAuthConfig
+   * } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+   *
+   * const kvOAuthClient = new Client(createGitHubOAuthConfig());
+   *
+   * export async function handleSignIn(request: Request) {
+   *  return await kvOAuthClient.signIn(request);
+   * }
+   * ```
+   */
   async signIn(request: Request, options?: SignInOptions) {
     return await signIn(request, this.oauthConfig, options);
   }
 
+  /**
+   * Handles the OAuth callback request for the given OAuth configuration, and
+   * then redirects the client to the success URL set in {@linkcode signIn}. The
+   * request URL must match the redirect URL of the OAuth application.
+   *
+   * @example
+   * ```ts
+   * import {
+   *   Client,
+   *   createGitHubOAuthConfig
+   * } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+   *
+   * const kvOAuthClient = new Client(createGitHubOAuthConfig());
+   *
+   * export async function handleOAuthCallback(request: Request) {
+   *   const { response, tokens, sessionId } = await kvOAuthClient.
+   *     handleCallback(request);
+   *
+   *    // Perform some actions with the `tokens` and `sessionId`.
+   *
+   *    return response;
+   * }
+   * ```
+   */
   async handleCallback(request: Request) {
     return await handleCallback(request, this.oauthConfig, {
       cookieOptions: this.options?.cookieOptions,
     });
   }
 
+  /**
+   * Handles the sign-out process, and then redirects the client to the given
+   * success URL.
+   *
+   * @see {@link https://deno.land/x/deno_kv_oauth#redirects-after-sign-in-and-sign-out}
+   *
+   * @example
+   * ```ts
+   * import {
+   *   Client,
+   *   createGitHubOAuthConfig
+   * } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+   *
+   * const kvOAuthClient = new Client(createGitHubOAuthConfig());
+   *
+   * export async function signOutHandler(request: Request) {
+   *   return kvOAuthClient.signOut(request);
+   * }
+   * ```
+   */
   async signOut(request: Request) {
     return await signOut(request, {
       cookieOptions: this.options?.cookieOptions,
+    });
+  }
+
+  /**
+   * Gets the session ID from the cookie header of a request. This can be used to
+   * check whether the client is signed-in by checking if the return value is
+   * defined.
+   *
+   * @example
+   * ```ts
+   * import {
+   *   Client,
+   *   createGitHubOAuthConfig
+   * } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+   *
+   * const kvOAuthClient = new Client(createGitHubOAuthConfig());
+   *
+   * export function handler(request: Request) {
+   *   const sessionId = kvOAuthClient.getSessionId(request);
+   *   const hasSessionIdCookie = sessionId !== undefined;
+   *
+   *   return Response.json({ sessionId, hasSessionIdCookie });
+   * }
+   * ```
+   */
+  getSessionId(request: Request) {
+    return getSessionId(request, {
+      cookieName: this.options?.cookieOptions?.name,
     });
   }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -18,3 +18,4 @@ export * from "./lib/create_spotify_oauth_config.ts";
 export * from "./lib/create_twitter_oauth_config.ts";
 export * from "./lib/get_required_env.ts";
 export * from "./lib/types.ts";
+export * from "./lib/client.ts";


### PR DESCRIPTION
This reduces the amount of configuration repetition when using this module. As seen in the README changes, this is particularly helpful when setting one's custom cookie settings.

Previously, I was against using classes in this codebase. However, now, this appears to be net positive.