### PR TITLE
feat: cookie name option for `getSessionId()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ This is required for OAuth solutions that span more than one sub-domain.
        case "/oauth/signout":
          return signOut(request, { cookieOptions });
        case "/protected-route":
-         return getSessionId(request) === undefined
+         return getSessionId(request, { cookieName: cookieOptions.name }) ===
+             undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");
        default:

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -2,6 +2,14 @@
 import { getCookies } from "../deps.ts";
 import { getCookieName, isHttps, SITE_COOKIE_NAME } from "./_http.ts";
 
+export interface GetSessionIdOptions {
+  /**
+   * The name of the cookie in the request. This must match the cookie name
+   * used in {@linkcode handleCallback} and {@linkcode signOut}.
+   */
+  cookieName?: string;
+}
+
 /**
  * Gets the session ID from the cookie header of a request. This can be used to
  * check whether the client is signed-in by checking if the return value is
@@ -19,7 +27,8 @@ import { getCookieName, isHttps, SITE_COOKIE_NAME } from "./_http.ts";
  * }
  * ```
  */
-export function getSessionId(request: Request) {
-  const cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
+export function getSessionId(request: Request, options?: GetSessionIdOptions) {
+  const cookieName = options?.cookieName ??
+    getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
   return getCookies(request.headers)[cookieName] as string | undefined;
 }

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -17,7 +17,10 @@ import {
 import { getAndDeleteOAuthSession } from "./_kv.ts";
 
 export interface HandleCallbackOptions {
-  /** Overwrites cookie properties set in the response */
+  /** Overwrites cookie properties set in the response. These must match the
+   * cookie properties used in {@linkcode getSessionId} and
+   * {@linkcode signOut}.
+   */
   cookieOptions?: Partial<Cookie>;
 }
 

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -10,7 +10,11 @@ import {
 } from "./_http.ts";
 
 export interface SignOutOptions {
-  /** Overwrites cookie properties set in the response */
+  /**
+   * Overwrites cookie properties set in the response. These must match the
+   * cookie properties used in {@linkcode getSessionId} and
+   * {@linkcode handleCallback}.
+   */
   cookieOptions?: Partial<Pick<Cookie, "name" | "path" | "domain">>;
 }
 


### PR DESCRIPTION
This piece was missed when adding cookie options to `handleCallback()` and `signOut()`.