### PR TITLE
feat: add `createHelpers()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,41 +166,40 @@ This is required for OAuth solutions that span more than one sub-domain.
 
 1. Create your OAuth application for your given provider.
 
-1. Create your web server using Deno KV OAuth's request handlers and helpers
-   with cookie options defined.
+1. Create your web server using Deno KV OAuth's helpers factory function with
+   cookie options defined.
 
    ```ts
    // server.ts
    import {
      createGitHubOAuthConfig,
-     getSessionId,
-     handleCallback,
-     signIn,
-     signOut,
+     createHelpers,
    } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
 
-   const oauthConfig = createGitHubOAuthConfig();
-
-   const cookieOptions = {
-     name: "__Secure-triple-choc",
-     domain: "news.site",
-   };
+   const {
+     signIn,
+     handleCallback,
+     signOut,
+     getSessionId,
+   } = createHelpers(createGitHubOAuthConfig(), {
+     cookieOptions: {
+       name: "__Secure-triple-choc",
+       domain: "news.site",
+     },
+   });
 
    async function handler(request: Request) {
      const { pathname } = new URL(request.url);
      switch (pathname) {
        case "/oauth/signin":
-         return await signIn(request, oauthConfig);
+         return await signIn(request);
        case "/oauth/callback":
-         const { response } = await handleCallback(request, oauthConfig, {
-           cookieOptions,
-         });
+         const { response } = await handleCallback(request);
          return response;
        case "/oauth/signout":
-         return signOut(request, { cookieOptions });
+         return signOut(request);
        case "/protected-route":
-         return getSessionId(request, { cookieName: cookieOptions.name }) ===
-             undefined
+         return getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");
        default:

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -1,0 +1,81 @@
+// Copyright 2023 the Deno authors. All rights reserved. MIT license.
+
+import { type Cookie, OAuth2ClientConfig } from "../deps.ts";
+import { getSessionId } from "./get_session_id.ts";
+import { handleCallback } from "./handle_callback.ts";
+import { signIn, type SignInOptions } from "./sign_in.ts";
+import { signOut } from "./sign_out.ts";
+
+export interface CreateHelpersOptions {
+  cookieOptions?: Partial<Cookie>;
+}
+
+/**
+ * Creates the full set of helpers with the given OAuth configuration and
+ * options.
+ *
+ * @example
+ * ```ts
+ * // server.ts
+ * import {
+ *   createGitHubOAuthConfig,
+ *   createHelpers,
+ * } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+ *
+ * const {
+ *   signIn,
+ *   handleCallback,
+ *   signOut,
+ *   getSessionId,
+ * } = createHelpers(createGitHubOAuthConfig(), {
+ *   cookieOptions: {
+ *     name: "__Secure-triple-choc",
+ *     domain: "news.site",
+ *   },
+ * });
+ *
+ * async function handler(request: Request) {
+ *   const { pathname } = new URL(request.url);
+ *   switch (pathname) {
+ *     case "/oauth/signin":
+ *       return await signIn(request);
+ *     case "/oauth/callback":
+ *       const { response } = await handleCallback(request);
+ *       return response;
+ *     case "/oauth/signout":
+ *       return signOut(request);
+ *     case "/protected-route":
+ *       return getSessionId(request) === undefined
+ *         ? new Response("Unauthorized", { status: 401 })
+ *         : new Response("You are allowed");
+ *     default:
+ *       return new Response(null, { status: 404 });
+ *   }
+ * }
+ *
+ * Deno.serve(handler);
+ * ```
+ */
+export function createHelpers(
+  oauthConfig: OAuth2ClientConfig,
+  options?: CreateHelpersOptions,
+) {
+  return {
+    async signIn(request: Request, options?: SignInOptions) {
+      return await signIn(request, oauthConfig, options);
+    },
+    async handleCallback(request: Request) {
+      return await handleCallback(request, oauthConfig, {
+        cookieOptions: options?.cookieOptions,
+      });
+    },
+    signOut(request: Request) {
+      return signOut(request, { cookieOptions: options?.cookieOptions });
+    },
+    getSessionId(request: Request) {
+      return getSessionId(request, {
+        cookieName: options?.cookieOptions?.name,
+      });
+    },
+  };
+}

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -20,7 +20,7 @@ export interface CreateHelpersOptions {
  * import {
  *   createGitHubOAuthConfig,
  *   createHelpers,
- * } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
+ * } from "https://deno.land/x/deno_kv_oauth/mod.ts";
  *
  * const {
  *   signIn,

--- a/mod.ts
+++ b/mod.ts
@@ -16,5 +16,6 @@ export * from "./lib/create_patreon_oauth_config.ts";
 export * from "./lib/create_slack_oauth_config.ts";
 export * from "./lib/create_spotify_oauth_config.ts";
 export * from "./lib/create_twitter_oauth_config.ts";
+export * from "./lib/create_helpers.ts";
 export * from "./lib/get_required_env.ts";
 export * from "./lib/types.ts";


### PR DESCRIPTION
This reduces the amount of configuration repetition when using this module. As seen in the README changes, this is particularly helpful when setting one's custom cookie settings.

This idea is made to compete with the `Client` class idea in #253. I prefer this change, as a factory function is more straightforward to conceptualise and maintain over a class, IMO.