### PR TITLE
fix: add site session database check

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ configurations.
        case "/oauth/signout":
          return signOut(request);
        case "/protected-route":
-         return getSessionId(request) === undefined
+         return await getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");
        default:
@@ -142,7 +142,7 @@ configurations.
        case "/oauth/signout":
          return signOut(request);
        case "/protected-route":
-         return getSessionId(request) === undefined
+         return await getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");
        default:
@@ -199,7 +199,7 @@ This is required for OAuth solutions that span more than one sub-domain.
        case "/oauth/signout":
          return signOut(request);
        case "/protected-route":
-         return getSessionId(request) === undefined
+         return await getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");
        default:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ configurations.
          const { response } = await handleCallback(request, oauthConfig);
          return response;
        case "/oauth/signout":
-         return signOut(request);
+         return await signOut(request);
        case "/protected-route":
          return await getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
@@ -140,7 +140,7 @@ configurations.
          const { response } = await handleCallback(request, oauthConfig);
          return response;
        case "/oauth/signout":
-         return signOut(request);
+         return await signOut(request);
        case "/protected-route":
          return await getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
@@ -197,7 +197,7 @@ This is required for OAuth solutions that span more than one sub-domain.
          const { response } = await handleCallback(request);
          return response;
        case "/oauth/signout":
-         return signOut(request);
+         return await signOut(request);
        case "/protected-route":
          return await getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })

--- a/demo.ts
+++ b/demo.ts
@@ -23,8 +23,8 @@ loadSync({ export: true });
  */
 const oauthConfig = createGitHubOAuthConfig();
 
-function indexHandler(request: Request) {
-  const sessionId = getSessionId(request);
+async function indexHandler(request: Request) {
+  const sessionId = await getSessionId(request);
   const hasSessionIdCookie = sessionId !== undefined;
 
   const body = `

--- a/lib/_http.ts
+++ b/lib/_http.ts
@@ -57,6 +57,6 @@ export function getSuccessUrl(request: Request): string {
 export function getSessionIdCookie(
   request: Request,
   cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(request.url)),
-) {
-  return getCookies(request.headers)[cookieName] as string | undefined;
+): string | undefined {
+  return getCookies(request.headers)[cookieName];
 }

--- a/lib/_http.ts
+++ b/lib/_http.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { type Cookie, Status } from "../deps.ts";
+import { type Cookie, getCookies, Status } from "../deps.ts";
 
 export const OAUTH_COOKIE_NAME = "oauth-session";
 export const SITE_COOKIE_NAME = "site-session";
@@ -52,4 +52,11 @@ export function getSuccessUrl(request: Request) {
   }
 
   return "/";
+}
+
+export function getSessionIdCookie(
+  request: Request,
+  cookieName = getCookieName(SITE_COOKIE_NAME, isHttps(request.url)),
+) {
+  return getCookies(request.headers)[cookieName] as string | undefined;
 }

--- a/lib/_kv.ts
+++ b/lib/_kv.ts
@@ -60,9 +60,15 @@ export async function setSession(id: string) {
 
 export async function deleteSession(id: string) {
   const key = [SITE_SESSION_PREFIX, id];
-  const res = await kv.get<SiteSession>(key);
-  if (res.value === null) {
+  const sessionRes = await kv.get<SiteSession>(key);
+  if (sessionRes.value === null) {
     throw new Deno.errors.NotFound("Site session not found");
   }
-  await kv.delete(key);
+
+  const res = await kv.atomic()
+    .check(sessionRes)
+    .delete(key)
+    .commit();
+
+  if (!res.ok) throw new Error("Failed to delete site session");
 }

--- a/lib/_kv.ts
+++ b/lib/_kv.ts
@@ -61,16 +61,16 @@ type SiteSession = true;
 
 const SITE_SESSION_PREFIX = "site_sessions";
 
-export async function isSession(id: string) {
+export async function isSiteSession(id: string) {
   const res = await kv.get<SiteSession>([SITE_SESSION_PREFIX, id]);
   return res.value !== null;
 }
 
-export async function setSession(id: string, expireIn?: number) {
+export async function setSiteSession(id: string, expireIn?: number) {
   await kv.set([SITE_SESSION_PREFIX, id], true, { expireIn });
 }
 
-export async function deleteSession(id: string) {
+export async function deleteSiteSession(id: string) {
   const key = [SITE_SESSION_PREFIX, id];
   const sessionRes = await kv.get<SiteSession>(key);
   if (sessionRes.value === null) {

--- a/lib/_kv.ts
+++ b/lib/_kv.ts
@@ -63,7 +63,7 @@ type SiteSession = true;
 
 const SITE_SESSION_PREFIX = "site_sessions";
 
-export async function isSiteSession(id: string) {
+export async function isSiteSession(id: string): Promise<boolean> {
   const res = await kv.get<SiteSession>([SITE_SESSION_PREFIX, id]);
   return res.value !== null;
 }

--- a/lib/_kv.ts
+++ b/lib/_kv.ts
@@ -66,8 +66,8 @@ export async function isSession(id: string) {
   return res.value !== null;
 }
 
-export async function setSession(id: string) {
-  await kv.set([SITE_SESSION_PREFIX, id], true);
+export async function setSession(id: string, expireIn?: number) {
+  await kv.set([SITE_SESSION_PREFIX, id], true, { expireIn });
 }
 
 export async function deleteSession(id: string) {

--- a/lib/_kv.ts
+++ b/lib/_kv.ts
@@ -73,16 +73,5 @@ export async function setSiteSession(id: string, expireIn?: number) {
 }
 
 export async function deleteSiteSession(id: string) {
-  const key = [SITE_SESSION_PREFIX, id];
-  const sessionRes = await kv.get<SiteSession>(key);
-  if (sessionRes.value === null) {
-    throw new Deno.errors.NotFound("Site session not found");
-  }
-
-  const res = await kv.atomic()
-    .check(sessionRes)
-    .delete(key)
-    .commit();
-
-  if (!res.ok) throw new Error("Failed to delete site session");
+  await kv.delete([SITE_SESSION_PREFIX, id]);
 }

--- a/lib/_kv.ts
+++ b/lib/_kv.ts
@@ -45,6 +45,11 @@ export async function setOAuthSession(
   await kv.set([OAUTH_SESSIONS_PREFIX, id], value, options);
 }
 
+/**
+ * The site session is created on the server. It is stored in the database to
+ * later validate that a session was created on the server. It has no purpose
+ * beyond that. Hence, the value of the site session entry is arbitrary.
+ */
 type SiteSession = true;
 
 const SITE_SESSION_PREFIX = "site_sessions";

--- a/lib/_kv.ts
+++ b/lib/_kv.ts
@@ -44,3 +44,25 @@ export async function setOAuthSession(
 ) {
   await kv.set([OAUTH_SESSIONS_PREFIX, id], value, options);
 }
+
+type SiteSession = true;
+
+const SITE_SESSION_PREFIX = "site_sessions";
+
+export async function isSession(id: string) {
+  const res = await kv.get<SiteSession>([SITE_SESSION_PREFIX, id]);
+  return res.value !== null;
+}
+
+export async function setSession(id: string) {
+  await kv.set([SITE_SESSION_PREFIX, id], true);
+}
+
+export async function deleteSession(id: string) {
+  const key = [SITE_SESSION_PREFIX, id];
+  const res = await kv.get<SiteSession>(key);
+  if (res.value === null) {
+    throw new Deno.errors.NotFound("Site session not found");
+  }
+  await kv.delete(key);
+}

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -43,7 +43,7 @@ export interface CreateHelpersOptions {
  *       const { response } = await handleCallback(request);
  *       return response;
  *     case "/oauth/signout":
- *       return signOut(request);
+ *       return await signOut(request);
  *     case "/protected-route":
  *       return await getSessionId(request) === undefined
  *         ? new Response("Unauthorized", { status: 401 })
@@ -69,8 +69,8 @@ export function createHelpers(
         cookieOptions: options?.cookieOptions,
       });
     },
-    signOut(request: Request) {
-      return signOut(request, { cookieOptions: options?.cookieOptions });
+    async signOut(request: Request) {
+      return await signOut(request, { cookieOptions: options?.cookieOptions });
     },
     async getSessionId(request: Request) {
       return await getSessionId(request, {

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -66,8 +66,8 @@ export function createHelpers(
     sessionId: string;
     tokens: Tokens;
   }>;
-  signOut(request: Request): Response;
-  getSessionId(request: Request): string | undefined;
+  signOut(request: Request): Promise<Response>;
+  getSessionId(request: Request): Promise<string | undefined>;
 } {
   return {
     async signIn(request: Request, options?: SignInOptions) {

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -45,7 +45,7 @@ export interface CreateHelpersOptions {
  *     case "/oauth/signout":
  *       return signOut(request);
  *     case "/protected-route":
- *       return getSessionId(request) === undefined
+ *       return await getSessionId(request) === undefined
  *         ? new Response("Unauthorized", { status: 401 })
  *         : new Response("You are allowed");
  *     default:
@@ -72,8 +72,8 @@ export function createHelpers(
     signOut(request: Request) {
       return signOut(request, { cookieOptions: options?.cookieOptions });
     },
-    getSessionId(request: Request) {
-      return getSessionId(request, {
+    async getSessionId(request: Request) {
+      return await getSessionId(request, {
         cookieName: options?.cookieOptions?.name,
       });
     },

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { getSessionIdCookie } from "./_http.ts";
-import { isSession } from "https://deno.land/x/deno_kv_oauth/lib/_kv.ts";
+import { isSiteSession } from "https://deno.land/x/deno_kv_oauth/lib/_kv.ts";
 
 export interface GetSessionIdOptions {
   /**
@@ -32,7 +32,7 @@ export async function getSessionId(
   options?: GetSessionIdOptions,
 ) {
   const sessionId = getSessionIdCookie(request, options?.cookieName);
-  return (sessionId !== undefined && await isSession(sessionId))
+  return (sessionId !== undefined && await isSiteSession(sessionId))
     ? sessionId
     : undefined;
 }

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { getCookies } from "../deps.ts";
-import { getCookieName, isHttps, SITE_COOKIE_NAME } from "./_http.ts";
+import { getSessionIdCookie } from "./_http.ts";
+import { isSession } from "https://deno.land/x/deno_kv_oauth/lib/_kv.ts";
 
 export interface GetSessionIdOptions {
   /**
@@ -19,16 +19,20 @@ export interface GetSessionIdOptions {
  * ```ts
  * import { getSessionId } from "https://deno.land/x/deno_kv_oauth/mod.ts";
  *
- * export function handler(request: Request) {
- *   const sessionId = getSessionId(request);
+ * export async function handler(request: Request) {
+ *   const sessionId = await getSessionId(request);
  *   const hasSessionIdCookie = sessionId !== undefined;
  *
  *   return Response.json({ sessionId, hasSessionIdCookie });
  * }
  * ```
  */
-export function getSessionId(request: Request, options?: GetSessionIdOptions) {
-  const cookieName = options?.cookieName ??
-    getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
-  return getCookies(request.headers)[cookieName] as string | undefined;
+export async function getSessionId(
+  request: Request,
+  options?: GetSessionIdOptions,
+) {
+  const sessionId = getSessionIdCookie(request, options?.cookieName);
+  return (sessionId !== undefined && await isSession(sessionId))
+    ? sessionId
+    : undefined;
 }

--- a/lib/get_session_id_test.ts
+++ b/lib/get_session_id_test.ts
@@ -2,26 +2,29 @@
 import { assertEquals } from "../dev_deps.ts";
 import { SITE_COOKIE_NAME } from "./_http.ts";
 import { getSessionId } from "./get_session_id.ts";
+import { setSession } from "./_kv.ts";
 
-Deno.test("getSessionId() returns undefined when cookie is not defined", () => {
+Deno.test("getSessionId() returns undefined when cookie is not defined", async () => {
   const request = new Request("http://example.com");
 
-  assertEquals(getSessionId(request), undefined);
+  assertEquals(await getSessionId(request), undefined);
 });
 
-Deno.test("getSessionId() returns valid session ID", () => {
+Deno.test("getSessionId() returns valid session ID", async () => {
   const sessionId = crypto.randomUUID();
+  await setSession(sessionId);
   const request = new Request("http://example.com", {
     headers: {
       cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
     },
   });
 
-  assertEquals(getSessionId(request), sessionId);
+  assertEquals(await getSessionId(request), sessionId);
 });
 
-Deno.test("getSessionId() returns valid session ID when cookie name is defined", () => {
+Deno.test("getSessionId() returns valid session ID when cookie name is defined", async () => {
   const sessionId = crypto.randomUUID();
+  await setSession(sessionId);
   const cookieName = "triple-choc";
   const request = new Request("http://example.com", {
     headers: {
@@ -29,5 +32,5 @@ Deno.test("getSessionId() returns valid session ID when cookie name is defined",
     },
   });
 
-  assertEquals(getSessionId(request, { cookieName }), sessionId);
+  assertEquals(await getSessionId(request, { cookieName }), sessionId);
 });

--- a/lib/get_session_id_test.ts
+++ b/lib/get_session_id_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals } from "../dev_deps.ts";
 import { SITE_COOKIE_NAME } from "./_http.ts";
 import { getSessionId } from "./get_session_id.ts";
-import { setSession } from "./_kv.ts";
+import { setSiteSession } from "./_kv.ts";
 
 Deno.test("getSessionId() returns undefined when cookie is not defined", async () => {
   const request = new Request("http://example.com");
@@ -12,7 +12,7 @@ Deno.test("getSessionId() returns undefined when cookie is not defined", async (
 
 Deno.test("getSessionId() returns valid session ID", async () => {
   const sessionId = crypto.randomUUID();
-  await setSession(sessionId);
+  await setSiteSession(sessionId);
   const request = new Request("http://example.com", {
     headers: {
       cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
@@ -24,7 +24,7 @@ Deno.test("getSessionId() returns valid session ID", async () => {
 
 Deno.test("getSessionId() returns valid session ID when cookie name is defined", async () => {
   const sessionId = crypto.randomUUID();
-  await setSession(sessionId);
+  await setSiteSession(sessionId);
   const cookieName = "triple-choc";
   const request = new Request("http://example.com", {
     headers: {

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -14,7 +14,7 @@ import {
   redirect,
   SITE_COOKIE_NAME,
 } from "./_http.ts";
-import { getAndDeleteOAuthSession } from "./_kv.ts";
+import { getAndDeleteOAuthSession, setSession } from "./_kv.ts";
 
 export interface HandleCallbackOptions {
   /** Overwrites cookie properties set in the response. These must match the
@@ -64,6 +64,7 @@ export async function handleCallback(
     .code.getToken(request.url, oauthSession);
 
   const sessionId = crypto.randomUUID();
+  await setSession(sessionId);
 
   const response = redirect(oauthSession.successUrl);
   setCookie(

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -4,6 +4,7 @@ import {
   getCookies,
   OAuth2Client,
   type OAuth2ClientConfig,
+  SECOND,
   setCookie,
 } from "../deps.ts";
 import {
@@ -64,19 +65,20 @@ export async function handleCallback(
     .code.getToken(request.url, oauthSession);
 
   const sessionId = crypto.randomUUID();
-  await setSession(sessionId);
-
   const response = redirect(oauthSession.successUrl);
-  setCookie(
-    response.headers,
-    {
-      ...COOKIE_BASE,
-      name: getCookieName(SITE_COOKIE_NAME, isHttps(request.url)),
-      value: sessionId,
-      secure: isHttps(request.url),
-      ...options?.cookieOptions,
-    },
+  const cookie: Cookie = {
+    ...COOKIE_BASE,
+    name: getCookieName(SITE_COOKIE_NAME, isHttps(request.url)),
+    value: sessionId,
+    secure: isHttps(request.url),
+    ...options?.cookieOptions,
+  };
+  setCookie(response.headers, cookie);
+  await setSession(
+    sessionId,
+    cookie.maxAge ? cookie.maxAge * SECOND : undefined,
   );
+
   return {
     response,
     sessionId,

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -15,7 +15,7 @@ import {
   redirect,
   SITE_COOKIE_NAME,
 } from "./_http.ts";
-import { getAndDeleteOAuthSession, setSession } from "./_kv.ts";
+import { getAndDeleteOAuthSession, setSiteSession } from "./_kv.ts";
 
 export interface HandleCallbackOptions {
   /** Overwrites cookie properties set in the response. These must match the
@@ -74,7 +74,7 @@ export async function handleCallback(
     ...options?.cookieOptions,
   };
   setCookie(response.headers, cookie);
-  await setSession(
+  await setSiteSession(
     sessionId,
     cookie.maxAge ? cookie.maxAge * SECOND : undefined,
   );

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -35,7 +35,10 @@ export interface SignOutOptions {
  * }
  * ```
  */
-export async function signOut(request: Request, options?: SignOutOptions): Promise<Response> {
+export async function signOut(
+  request: Request,
+  options?: SignOutOptions,
+): Promise<Response> {
   const successUrl = getSuccessUrl(request);
   const response = redirect(successUrl);
 

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -31,7 +31,7 @@ export interface SignOutOptions {
  * import { signOut } from "https://deno.land/x/deno_kv_oauth/mod.ts";
  *
  * export async function signOutHandler(request: Request) {
- *   return signOut(request);
+ *   return await signOut(request);
  * }
  * ```
  */

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -9,7 +9,7 @@ import {
   redirect,
   SITE_COOKIE_NAME,
 } from "./_http.ts";
-import { deleteSession } from "./_kv.ts";
+import { deleteSiteSession } from "./_kv.ts";
 
 export interface SignOutOptions {
   /**
@@ -41,7 +41,7 @@ export async function signOut(request: Request, options?: SignOutOptions) {
 
   const sessionId = getSessionIdCookie(request, options?.cookieOptions?.name);
   if (sessionId === undefined) return response;
-  await deleteSession(sessionId);
+  await deleteSiteSession(sessionId);
 
   const cookieName = options?.cookieOptions?.name ??
     getCookieName(SITE_COOKIE_NAME, isHttps(request.url));

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -3,11 +3,13 @@ import { Cookie, deleteCookie } from "../deps.ts";
 import {
   COOKIE_BASE,
   getCookieName,
+  getSessionIdCookie,
   getSuccessUrl,
   isHttps,
   redirect,
   SITE_COOKIE_NAME,
 } from "./_http.ts";
+import { deleteSession } from "./_kv.ts";
 
 export interface SignOutOptions {
   /**
@@ -33,9 +35,13 @@ export interface SignOutOptions {
  * }
  * ```
  */
-export function signOut(request: Request, options?: SignOutOptions) {
+export async function signOut(request: Request, options?: SignOutOptions) {
   const successUrl = getSuccessUrl(request);
   const response = redirect(successUrl);
+
+  const sessionId = getSessionIdCookie(request, options?.cookieOptions?.name);
+  if (sessionId === undefined) return response;
+  await deleteSession(sessionId);
 
   const cookieName = options?.cookieOptions?.name ??
     getCookieName(SITE_COOKIE_NAME, isHttps(request.url));

--- a/lib/sign_out_test.ts
+++ b/lib/sign_out_test.ts
@@ -3,7 +3,7 @@ import { assertEquals, assertRejects } from "../dev_deps.ts";
 import { signOut } from "./sign_out.ts";
 import { SITE_COOKIE_NAME } from "./_http.ts";
 import { assertRedirect } from "./_test_utils.ts";
-import { setSession } from "./_kv.ts";
+import { setSiteSession } from "./_kv.ts";
 
 Deno.test("signOut() returns a redirect response if the user is not signed-in", async () => {
   const request = new Request("http://example.com/signout");
@@ -14,7 +14,7 @@ Deno.test("signOut() returns a redirect response if the user is not signed-in", 
 
 Deno.test("signOut() returns a response that signs out the signed-in user", async () => {
   const sessionId = crypto.randomUUID();
-  await setSession(sessionId);
+  await setSiteSession(sessionId);
   const request = new Request("http://example.com/signout", {
     headers: {
       cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
@@ -36,7 +36,7 @@ Deno.test("signOut() returns a response that signs out the signed-in user with c
     path: "/path",
   };
   const sessionId = crypto.randomUUID();
-  await setSession(sessionId);
+  await setSiteSession(sessionId);
   const request = new Request("http://example.com/signout", {
     headers: {
       cookie: `${cookieOptions.name}=${sessionId}`,

--- a/lib/sign_out_test.ts
+++ b/lib/sign_out_test.ts
@@ -1,10 +1,9 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "../dev_deps.ts";
+import { assertEquals, assertRejects } from "../dev_deps.ts";
 import { signOut } from "./sign_out.ts";
 import { SITE_COOKIE_NAME } from "./_http.ts";
 import { assertRedirect } from "./_test_utils.ts";
 import { setSession } from "./_kv.ts";
-import { assertRejects } from "https://deno.land/std@0.203.0/assert/assert_rejects.ts";
 
 Deno.test("signOut() returns a redirect response if the user is not signed-in", async () => {
   const request = new Request("http://example.com/signout");

--- a/lib/sign_out_test.ts
+++ b/lib/sign_out_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertRejects } from "../dev_deps.ts";
+import { assertEquals } from "../dev_deps.ts";
 import { signOut } from "./sign_out.ts";
 import { SITE_COOKIE_NAME } from "./_http.ts";
 import { assertRedirect } from "./_test_utils.ts";
@@ -48,20 +48,5 @@ Deno.test("signOut() returns a response that signs out the signed-in user with c
   assertEquals(
     response.headers.get("set-cookie"),
     `${cookieOptions.name}=; Domain=${cookieOptions.domain}; Path=${cookieOptions.path}; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
-  );
-});
-
-Deno.test("signOut() rejects when a session ID doesn't exist in the database", async () => {
-  const sessionId = crypto.randomUUID();
-  const request = new Request("http://example.com/signout", {
-    headers: {
-      cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
-    },
-  });
-
-  await assertRejects(
-    async () => await signOut(request),
-    Deno.errors.NotFound,
-    "Site session not found",
   );
 });


### PR DESCRIPTION
This change adds a database check to `getSessionId()` and `signOut()`.

A session ID entry is created in KV on the originating server. This entry is then checked for and deleted when appropriate.