### PR TITLE
docs: rework "Get Started with Fresh" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,14 +248,14 @@ This is required for OAuth solutions that span more than one sub-domain.
        },
        {
          path: "/signout",
-         handler(req) {
-           return signOut(req);
+         async handler(req) {
+           return await signOut(req);
          },
        },
        {
          path: "/protected",
-         handler(req) {
-           return getSessionId(req) === undefined
+         async handler(req) {
+           return await getSessionId(req) === undefined
              ? new Response("Unauthorized", { status: 401 })
              : new Response("You are allowed");
          },

--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ Check out the full documentation and API reference
 
 ## How-to
 
-### Get Started with [Fresh](https://fresh.deno.dev/)
-
-See
-[Fresh's documentation](https://fresh.deno.dev/docs/examples/using-deno-kv-oauth)
-on how to get started with the Deno KV OAuth Fresh plugin.
-
 ### Get Started with a Pre-Defined OAuth Configuration
 
 See [here](#providers) for the list of OAuth providers with pre-defined
@@ -215,6 +209,68 @@ This is required for OAuth solutions that span more than one sub-domain.
 
    ```bash
    GITHUB_CLIENT_ID=xxx GITHUB_CLIENT_SECRET=xxx deno run --unstable --allow-env --allow-net server.ts
+   ```
+
+### Get Started with [Fresh](https://fresh.deno.dev/)
+
+1. Create your OAuth application for your given provider.
+
+1. Create your OAuth configuration and Fresh plugin.
+
+   ```ts
+   // plugins/kv_oauth.ts
+   import {
+     createGitHubOAuthConfig,
+     createHelpers,
+   } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   import type { Plugin } from "$fresh/server.ts";
+
+   const { signIn, handleCallback, signOut, getSessionId } = createHelpers(
+     createGitHubOAuthConfig(),
+   );
+
+   export default {
+     name: "kv-oauth",
+     routes: [
+       {
+         path: "/signin",
+         async handler(req) {
+           return await signIn(req);
+         },
+       },
+       {
+         path: "/callback",
+         async handler(req) {
+           // Return object also includes `accessToken` and `sessionId` properties.
+           const { response } = await handleCallback(req);
+           return response;
+         },
+       },
+       {
+         path: "/signout",
+         handler(req) {
+           return signOut(req);
+         },
+       },
+       {
+         path: "/protected",
+         handler(req) {
+           return getSessionId(req) === undefined
+             ? new Response("Unauthorized", { status: 401 })
+             : new Response("You are allowed");
+         },
+       },
+     ],
+   } as Plugin;
+   ```
+
+1. [Add the plugin to your Fresh app.](https://fresh.deno.dev/docs/concepts/plugins)
+
+1. Start your Fresh server with the necessary
+   [environment variables](#environment-variables).
+
+   ```bash
+   GITHUB_CLIENT_ID=xxx GITHUB_CLIENT_SECRET=xxx deno task start
    ```
 
 ### Run the Demo Locally

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,13 @@
 {
   "lock": false,
   "imports": {
-    "https://deno.land/x/deno_kv_oauth/": "./"
+    "https://deno.land/x/deno_kv_oauth/": "./",
+    "$fresh/": "https://deno.land/x/fresh@1.5.2/",
+    "preact": "https://esm.sh/preact@10.18.1",
+    "preact/": "https://esm.sh/preact@10.18.1/",
+    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.2",
+    "@preact/signals": "https://esm.sh/*@preact/signals@1.2.1",
+    "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.5.0"
   },
   "tasks": {
     "demo": "deno run --allow-net --allow-env --allow-read --unstable --watch=demo.ts,mod.ts demo.ts",
@@ -13,7 +19,8 @@
     "cov:clean": "rm -rf cov html_cov cov.lcov",
     "cov:gen": "deno coverage ./cov/ --lcov --output=cov.lcov",
     "cov:view": "genhtml -o html_cov cov.lcov && open html_cov/index.html",
-    "update": "deno run -A https://deno.land/x/udd/main.ts --test=\"deno task test\" deps.ts dev_deps.ts"
+    "update": "deno run -A https://deno.land/x/udd/main.ts --test=\"deno task test\" deps.ts dev_deps.ts",
+    "update:fresh": "deno run -A -r https://fresh.deno.dev/update ."
   },
   "exclude": [
     "cov/"

--- a/tools/check_license.ts
+++ b/tools/check_license.ts
@@ -19,7 +19,6 @@ async function checkLicense(path: string) {
 for await (
   const { path } of walk(new URL("../", import.meta.url), {
     exts: [".ts"],
-    skip: [/cov/g],
     includeDirs: false,
   })
 ) {


### PR DESCRIPTION
I was working on re-introducing the Fresh plugin and realised it might be best to have a "Get Started with Fresh" section instead. A clear, easy-to-follow guide instead of a plugin would avoid the engineering cost that a Fresh plugin would incur. `createHandlers()` also provides most of the consistency benefits a Fresh plugin would have.

This section provides a solid starting point for those wanting to use Fresh and this module.