### PR TITLE
revert: remove `@$VERSION` from imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ configurations.
      handleCallback,
      signIn,
      signOut,
-   } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
 
    const oauthConfig = createGitHubOAuthConfig();
 
@@ -115,7 +115,7 @@ configurations.
      type OAuth2ClientConfig,
      signIn,
      signOut,
-   } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
 
    const oauthConfig: OAuth2ClientConfig = {
      clientId: getRequiredEnv("CUSTOM_CLIENT_ID"),
@@ -168,7 +168,7 @@ This is required for OAuth solutions that span more than one sub-domain.
    import {
      createGitHubOAuthConfig,
      createHelpers,
-   } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
 
    const {
      signIn,
@@ -222,7 +222,7 @@ This is required for OAuth solutions that span more than one sub-domain.
    import {
      createGitHubOAuthConfig,
      createHelpers,
-   } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
    import type { Plugin } from "$fresh/server.ts";
 
    const { signIn, handleCallback, signOut, getSessionId } = createHelpers(

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "lock": false,
   "imports": {
-    "https://deno.land/x/deno_kv_oauth/": "./",
+    "https://deno.land/x/deno_kv_oauth@$VERSION/": "./",
     "$fresh/": "https://deno.land/x/fresh@1.5.2/",
     "preact": "https://esm.sh/preact@10.18.1",
     "preact/": "https://esm.sh/preact@10.18.1/",

--- a/lib/create_auth0_oauth_config.ts
+++ b/lib/create_auth0_oauth_config.ts
@@ -13,7 +13,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createAuth0OAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createAuth0OAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createAuth0OAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",

--- a/lib/create_discord_oauth_config.ts
+++ b/lib/create_discord_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createDiscordOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createDiscordOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createDiscordOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",

--- a/lib/create_dropbox_oauth_config.ts
+++ b/lib/create_dropbox_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createDropboxOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createDropboxOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createDropboxOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback"

--- a/lib/create_facebook_oauth_config.ts
+++ b/lib/create_facebook_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createFacebookOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createFacebookOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createFacebookOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",

--- a/lib/create_github_oauth_config.ts
+++ b/lib/create_github_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createGitHubOAuthConfig();
  * ```

--- a/lib/create_gitlab_oauth_config.ts
+++ b/lib/create_gitlab_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createGitLabOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createGitLabOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createGitLabOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",

--- a/lib/create_google_oauth_config.ts
+++ b/lib/create_google_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createGoogleOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createGoogleOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createGoogleOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -20,7 +20,7 @@ export interface CreateHelpersOptions {
  * import {
  *   createGitHubOAuthConfig,
  *   createHelpers,
- * } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const {
  *   signIn,

--- a/lib/create_notion_oauth_config.ts
+++ b/lib/create_notion_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createNotionOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createNotionOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createNotionOAuthConfig();
  * ```

--- a/lib/create_okta_oauth_config.ts
+++ b/lib/create_okta_oauth_config.ts
@@ -13,7 +13,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createOktaOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createOktaOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createOktaOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",

--- a/lib/create_patreon_oauth_config.ts
+++ b/lib/create_patreon_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createPatreonOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createPatreonOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createPatreonOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",

--- a/lib/create_slack_oauth_config.ts
+++ b/lib/create_slack_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createSlackOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createSlackOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createSlackOAuthConfig({
  *   scope: "users.profile:read",

--- a/lib/create_spotify_oauth_config.ts
+++ b/lib/create_spotify_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createSpotifyOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createSpotifyOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createSpotifyOAuthConfig({
  *   scope: "user-read-private user-read-email"

--- a/lib/create_twitter_oauth_config.ts
+++ b/lib/create_twitter_oauth_config.ts
@@ -12,7 +12,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  *
  * @example
  * ```ts
- * import { createTwitterOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createTwitterOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createTwitterOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",

--- a/lib/get_required_env.ts
+++ b/lib/get_required_env.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```ts
- * import { getRequiredEnv } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { getRequiredEnv } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * getRequiredEnv("HOME"); // Returns "/home/alice"
  * ```

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -1,6 +1,6 @@
 // Copyright 2023 the Deno authors. All rights reserved. MIT license.
 import { getSessionIdCookie } from "./_http.ts";
-import { isSiteSession } from "https://deno.land/x/deno_kv_oauth/lib/_kv.ts";
+import { isSiteSession } from "./_kv.ts";
 
 export interface GetSessionIdOptions {
   /**
@@ -17,7 +17,7 @@ export interface GetSessionIdOptions {
  *
  * @example
  * ```ts
- * import { getSessionId } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { getSessionId } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * export async function handler(request: Request) {
  *   const sessionId = await getSessionId(request);

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -33,7 +33,7 @@ export interface HandleCallbackOptions {
  *
  * @example
  * ```ts
- * import { handleCallback, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { handleCallback, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createGitHubOAuthConfig();
  *

--- a/lib/sign_in.ts
+++ b/lib/sign_in.ts
@@ -29,7 +29,7 @@ export interface SignInOptions {
  *
  * @example
  * ```ts
- * import { signIn, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { signIn, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * const oauthConfig = createGitHubOAuthConfig();
  *

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -28,7 +28,7 @@ export interface SignOutOptions {
  *
  * @example
  * ```ts
- * import { signOut } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { signOut } from "https://deno.land/x/deno_kv_oauth@$VERSION/mod.ts";
  *
  * export async function signOutHandler(request: Request) {
  *   return await signOut(request);


### PR DESCRIPTION
Leaving this string in encourages version pinning, which is a good practice.