### PR TITLE
chore: fix `update` workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           name: ${{ matrix.os }}
           files: cov.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
The `peter-evans/create-pull-request@v6` action requires the `token` field to be defined for the `codecov/codecov-action@v4` action.

See https://github.com/codecov/codecov-action#usage