### PR TITLE
feat: `createAwsCognitoOAuthConfig()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ The following providers have pre-defined OAuth configurations:
 1. [Auth0](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAuth0OAuthConfig)
 1. [AzureAD](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADAuthConfig)
 1. [AzureADB2C](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADB2CAuthConfig)
-1. [Cognito User Pool](https://deno.land/x/deno_kv_oauth/mod.ts?s=createCognitoUserPoolOAuthConfig)
+1. [AWS Cognito User Pool](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAwsCognitoOAuthConfig)
 1. [Discord](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDiscordOAuthConfig)
 1. [Dropbox](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDropboxOAuthConfig)
 1. [Facebook](https://deno.land/x/deno_kv_oauth/mod.ts?s=createFacebookOAuthConfig)
@@ -343,7 +343,7 @@ starting your server. E.g. `DISCORD`, `GOOGLE`, or `SLACK`.
    [Client secret](https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/)
    of a given OAuth application.
 1. `PROVIDER_DOMAIN` (optional) - Server domain of a given OAuth application.
-   Required for Auth0, AzureADB2C, Cognito User Pool, and Okta.
+   Required for Auth0, AzureADB2C, AWS Cognito, and Okta.
 
 > Note: reading environment variables requires the
 > `--allow-env[=<VARIABLE_NAME>...]` permission flag. See

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ The following providers have pre-defined OAuth configurations:
 1. [Auth0](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAuth0OAuthConfig)
 1. [AzureAD](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADAuthConfig)
 1. [AzureADB2C](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADB2CAuthConfig)
+1. [Cognito User Pool](https://deno.land/x/deno_kv_oauth/mod.ts?s=createCognitoUserPoolOAuthConfig)
 1. [Discord](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDiscordOAuthConfig)
 1. [Dropbox](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDropboxOAuthConfig)
 1. [Facebook](https://deno.land/x/deno_kv_oauth/mod.ts?s=createFacebookOAuthConfig)

--- a/README.md
+++ b/README.md
@@ -314,9 +314,10 @@ is set in the following order of precedence:
 The following providers have pre-defined OAuth configurations:
 
 1. [Auth0](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAuth0OAuthConfig)
-1. [AzureAD](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADAuthConfig)
-1. [AzureADB2C](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADB2CAuthConfig)
+   s=createAzureADB2CAuthConfig)
 1. [AWS Cognito User Pool](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAwsCognitoOAuthConfig)
+1. [AzureAD](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADAuthConfig)
+1. [AzureADB2C](https://deno.land/x/deno_kv_oauth/mod.ts?
 1. [Discord](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDiscordOAuthConfig)
 1. [Dropbox](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDropboxOAuthConfig)
 1. [Facebook](https://deno.land/x/deno_kv_oauth/mod.ts?s=createFacebookOAuthConfig)

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The following providers have pre-defined OAuth configurations:
 1. [AWS Cognito User Pool](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAwsCognitoOAuthConfig)
 1. [AzureAD](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADAuthConfig)
 1. [AzureADB2C](https://deno.land/x/deno_kv_oauth/mod.ts?
+   s=createAzureADB2CAuthConfig)
 1. [Discord](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDiscordOAuthConfig)
 1. [Dropbox](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDropboxOAuthConfig)
 1. [Facebook](https://deno.land/x/deno_kv_oauth/mod.ts?s=createFacebookOAuthConfig)

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ starting your server. E.g. `DISCORD`, `GOOGLE`, or `SLACK`.
    [Client secret](https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/)
    of a given OAuth application.
 1. `PROVIDER_DOMAIN` (optional) - Server domain of a given OAuth application.
-   Only required for Okta and Auth0.
+   Required for Auth0, AzureADB2C, Cognito User Pool, and Okta.
 
 > Note: reading environment variables requires the
 > `--allow-env[=<VARIABLE_NAME>...]` permission flag. See

--- a/README.md
+++ b/README.md
@@ -314,11 +314,9 @@ is set in the following order of precedence:
 The following providers have pre-defined OAuth configurations:
 
 1. [Auth0](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAuth0OAuthConfig)
-   s=createAzureADB2CAuthConfig)
 1. [AWS Cognito User Pool](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAwsCognitoOAuthConfig)
 1. [AzureAD](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADAuthConfig)
-1. [AzureADB2C](https://deno.land/x/deno_kv_oauth/mod.ts?
-   s=createAzureADB2CAuthConfig)
+1. [AzureADB2C](https://deno.land/x/deno_kv_oauth/mod.ts?s=createAzureADB2CAuthConfig)
 1. [Discord](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDiscordOAuthConfig)
 1. [Dropbox](https://deno.land/x/deno_kv_oauth/mod.ts?s=createDropboxOAuthConfig)
 1. [Facebook](https://deno.land/x/deno_kv_oauth/mod.ts?s=createFacebookOAuthConfig)

--- a/lib/create_aws_cognito_oauth_config.ts
+++ b/lib/create_aws_cognito_oauth_config.ts
@@ -5,17 +5,17 @@ import { getRequiredEnv } from "./get_required_env.ts";
 /**
  * Returns the OAuth configuration for an Amazon Cognito user pool.
  *
- * Requires `--allow-env[=COGNITO_USER_POOL_CLIENT_ID,COGNITO_USER_POOL_CLIENT_SECRET,COGNITO_USER_POOL_DOMAIN]`
+ * Requires `--allow-env[=AWS_COGNITO_CLIENT_ID,AWS_COGNITO_CLIENT_SECRET,AWS_COGNITO_DOMAIN]`
  * permissions and environment variables:
- * 1. `COGNITO_USER_POOL_CLIENT_ID`
- * 2. `COGNITO_USER_POOL_CLIENT_SECRET`
- * 3. `COGNITO_USER_POOL_DOMAIN`
+ * 1. `AWS_COGNITO_CLIENT_ID`
+ * 2. `AWS_COGNITO_CLIENT_SECRET`
+ * 3. `AWS_COGNITO_DOMAIN`
  *
  * @example
  * ```ts
- * import { createCognitoUserPoolOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ * import { createAwsCognitoOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
  *
- * const oauthConfig = createCognitoUserPoolOAuthConfig({
+ * const oauthConfig = createAwsCognitoOAuthConfig({
  *   redirectUri: "http://localhost:8000/callback",
  *   scope: "openid"
  * });
@@ -24,7 +24,7 @@ import { getRequiredEnv } from "./get_required_env.ts";
  * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/federation-endpoints-oauth-grants.html}
  */
 
-export function createCognitoUserPoolOAuthConfig(
+export function createAwsCognitoOAuthConfig(
   config: {
     /** @see {@linkcode OAuth2ClientConfig.redirectUri} */
     redirectUri: string;
@@ -32,11 +32,11 @@ export function createCognitoUserPoolOAuthConfig(
     scope?: string | string[];
   },
 ): OAuth2ClientConfig {
-  const domain = getRequiredEnv("COGNITO_USER_POOL_DOMAIN");
+  const domain = getRequiredEnv("AWS_COGNITO_DOMAIN");
   const baseURL = `https://${domain}/oauth2`;
   return {
-    clientId: getRequiredEnv("COGNITO_USER_POOL_CLIENT_ID"),
-    clientSecret: getRequiredEnv("COGNITO_USER_POOL_CLIENT_SECRET"),
+    clientId: getRequiredEnv("AWS_COGNITO_CLIENT_ID"),
+    clientSecret: getRequiredEnv("AWS_COGNITO_CLIENT_SECRET"),
     authorizationEndpointUri: `${baseURL}/authorize`,
     tokenUri: `${baseURL}/token`,
     redirectUri: config.redirectUri,

--- a/lib/create_cognito_user_pool_oauth_config.ts
+++ b/lib/create_cognito_user_pool_oauth_config.ts
@@ -1,0 +1,45 @@
+// Copyright 2023-2024 the Deno authors. All rights reserved. MIT license.
+import type { OAuth2ClientConfig } from "../deps.ts";
+import { getRequiredEnv } from "./get_required_env.ts";
+
+/**
+ * Returns the OAuth configuration for an Amazon Cognito user pool.
+ *
+ * Requires `--allow-env[=COGNITO_USER_POOL_CLIENT_ID,COGNITO_USER_POOL_CLIENT_SECRET,COGNITO_USER_POOL_DOMAIN]`
+ * permissions and environment variables:
+ * 1. `COGNITO_USER_POOL_CLIENT_ID`
+ * 2. `COGNITO_USER_POOL_CLIENT_SECRET`
+ * 3. `COGNITO_USER_POOL_DOMAIN`
+ *
+ * @example
+ * ```ts
+ * import { createCognitoUserPoolOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ *
+ * const oauthConfig = createCognitoUserPoolOAuthConfig({
+ *   redirectUri: "http://localhost:8000/callback",
+ *   scope: "openid"
+ * });
+ * ```
+ *
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/federation-endpoints-oauth-grants.html}
+ */
+
+export function createCognitoUserPoolOAuthConfig(
+  config: {
+    /** @see {@linkcode OAuth2ClientConfig.redirectUri} */
+    redirectUri: string;
+    /** @see {@linkcode OAuth2ClientConfig.defaults.scope} */
+    scope?: string | string[];
+  },
+): OAuth2ClientConfig {
+  const domain = getRequiredEnv("COGNITO_USER_POOL_DOMAIN");
+  const baseURL = `https://${domain}/oauth2`;
+  return {
+    clientId: getRequiredEnv("COGNITO_USER_POOL_CLIENT_ID"),
+    clientSecret: getRequiredEnv("COGNITO_USER_POOL_CLIENT_SECRET"),
+    authorizationEndpointUri: `${baseURL}/authorize`,
+    tokenUri: `${baseURL}/token`,
+    redirectUri: config.redirectUri,
+    defaults: { scope: config?.scope },
+  };
+}

--- a/mod.ts
+++ b/mod.ts
@@ -6,7 +6,7 @@ export * from "./lib/sign_out.ts";
 export * from "./lib/create_auth0_oauth_config.ts";
 export * from "./lib/create_azure_ad_oauth_config.ts";
 export * from "./lib/create_azure_adb2c_oauth_config.ts";
-export * from "./lib/create_cognito_user_pool_oauth_config.ts";
+export * from "./lib/create_aws_cognito_oauth_config.ts";
 export * from "./lib/create_discord_oauth_config.ts";
 export * from "./lib/create_dropbox_oauth_config.ts";
 export * from "./lib/create_facebook_oauth_config.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -6,6 +6,7 @@ export * from "./lib/sign_out.ts";
 export * from "./lib/create_auth0_oauth_config.ts";
 export * from "./lib/create_azure_ad_oauth_config.ts";
 export * from "./lib/create_azure_adb2c_oauth_config.ts";
+export * from "./lib/create_cognito_user_pool_oauth_config.ts";
 export * from "./lib/create_discord_oauth_config.ts";
 export * from "./lib/create_dropbox_oauth_config.ts";
 export * from "./lib/create_facebook_oauth_config.ts";


### PR DESCRIPTION
Adds the configuration for a Cognito User Pool provider.

This assumes users have their user pool app client properly configured. Namely, it needs to have a client secret generated, have the appropriate callback URLs registered, and support the AuthorizationCodeGrant flow. 

Resolves #310

### Demo App Screenshots

#### Signed Out
<img width="1178" alt="Screenshot 2024-03-06 at 11 00 58 AM" src="https://github.com/denoland/deno_kv_oauth/assets/2080729/7b99daba-fadd-4b74-9f6a-798f5fff9c56">

#### Signed In
<img width="1178" alt="Screenshot 2024-03-06 at 11 01 18 AM" src="https://github.com/denoland/deno_kv_oauth/assets/2080729/84eb17e5-6bc6-43db-a192-74ba903d2ea1">
