### PR TITLE
feat: `KvOAuth` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,33 +52,31 @@ configurations.
 
 1. Create your OAuth application for your given provider.
 
-1. Create your web server using Deno KV OAuth's request handlers, helpers and
-   pre-defined OAuth configuration.
+1. Create your web server using a KV OAuth instance and pre-defined OAuth
+   configuration.
 
    ```ts
    // server.ts
    import {
      createGitHubOAuthConfig,
-     getSessionId,
-     handleCallback,
-     signIn,
-     signOut,
+     KvOAuth,
    } from "https://deno.land/x/deno_kv_oauth/mod.ts";
 
    const oauthConfig = createGitHubOAuthConfig();
+   const kvOAuth = new KvOAuth(oauthConfig);
 
    async function handler(request: Request) {
      const { pathname } = new URL(request.url);
      switch (pathname) {
        case "/oauth/signin":
-         return await signIn(request, oauthConfig);
+         return await kvOAuth.signIn(request);
        case "/oauth/callback":
-         const { response } = await handleCallback(request, oauthConfig);
+         const { response } = await kvOAuth.handleCallback(request);
          return response;
        case "/oauth/signout":
-         return await signOut(request);
+         return await kvOAuth.signOut(request);
        case "/protected-route":
-         return await getSessionId(request) === undefined
+         return await kvOAuth.getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");
        default:
@@ -103,18 +101,15 @@ configurations.
 
 1. Create your OAuth application for your given provider.
 
-1. Create your web server using Deno KV OAuth's request handlers and helpers,
-   and custom OAuth configuration.
+1. Create your web server using a KV OAuth instance and custom OAuth
+   configuration.
 
    ```ts
    // server.ts
    import {
      getRequiredEnv,
-     getSessionId,
-     handleCallback,
+     KvOAuth,
      type OAuth2ClientConfig,
-     signIn,
-     signOut,
    } from "https://deno.land/x/deno_kv_oauth/mod.ts";
 
    const oauthConfig: OAuth2ClientConfig = {
@@ -124,19 +119,20 @@ configurations.
      tokenUri: "https://custom.com/oauth/token",
      redirectUri: "https://my-site.com/another-dir/callback",
    };
+   const kvOAuth = new KvOAuth(oauthConfig);
 
    async function handler(request: Request) {
      const { pathname } = new URL(request.url);
      switch (pathname) {
        case "/oauth/signin":
-         return await signIn(request, oauthConfig);
+         return await kvOAuth.signIn(request);
        case "/another-dir/callback":
-         const { response } = await handleCallback(request, oauthConfig);
+         const { response } = await kvOAuth.handleCallback(request);
          return response;
        case "/oauth/signout":
-         return await signOut(request);
+         return await kvOAuth.signOut(request);
        case "/protected-route":
-         return await getSessionId(request) === undefined
+         return await kvOAuth.getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");
        default:
@@ -160,22 +156,17 @@ This is required for OAuth solutions that span more than one sub-domain.
 
 1. Create your OAuth application for your given provider.
 
-1. Create your web server using Deno KV OAuth's helpers factory function with
-   cookie options defined.
+1. Create your web server using a KV OAuth instance with cookie options defined.
 
    ```ts
    // server.ts
    import {
      createGitHubOAuthConfig,
-     createHelpers,
+     KvOAuth,
    } from "https://deno.land/x/deno_kv_oauth/mod.ts";
 
-   const {
-     signIn,
-     handleCallback,
-     signOut,
-     getSessionId,
-   } = createHelpers(createGitHubOAuthConfig(), {
+   const oauthConfig = createGitHubOAuthConfig();
+   const kvOAuth = new KvOAuth(oauthConfig, {
      cookieOptions: {
        name: "__Secure-triple-choc",
        domain: "news.site",
@@ -186,14 +177,14 @@ This is required for OAuth solutions that span more than one sub-domain.
      const { pathname } = new URL(request.url);
      switch (pathname) {
        case "/oauth/signin":
-         return await signIn(request);
+         return await kvOAuth.signIn(request);
        case "/oauth/callback":
-         const { response } = await handleCallback(request);
+         const { response } = await kvOAuth.handleCallback(request);
          return response;
        case "/oauth/signout":
-         return await signOut(request);
+         return await kvOAuth.signOut(request);
        case "/protected-route":
-         return await getSessionId(request) === undefined
+         return await kvOAuth.getSessionId(request) === undefined
            ? new Response("Unauthorized", { status: 401 })
            : new Response("You are allowed");
        default:
@@ -221,13 +212,12 @@ This is required for OAuth solutions that span more than one sub-domain.
    // plugins/kv_oauth.ts
    import {
      createGitHubOAuthConfig,
-     createHelpers,
+     KvOAuth,
    } from "https://deno.land/x/deno_kv_oauth/mod.ts";
    import type { Plugin } from "$fresh/server.ts";
 
-   const { signIn, handleCallback, signOut, getSessionId } = createHelpers(
-     createGitHubOAuthConfig(),
-   );
+   const oauthConfig = createGitHubOAuthConfig();
+   const kvOAuth = new KvOAuth(oauthConfig);
 
    export default {
      name: "kv-oauth",
@@ -235,27 +225,27 @@ This is required for OAuth solutions that span more than one sub-domain.
        {
          path: "/signin",
          async handler(req) {
-           return await signIn(req);
+           return await kvOAuth.signIn(req);
          },
        },
        {
          path: "/callback",
          async handler(req) {
            // Return object also includes `accessToken` and `sessionId` properties.
-           const { response } = await handleCallback(req);
+           const { response } = await kvOAuth.handleCallback(req);
            return response;
          },
        },
        {
          path: "/signout",
          async handler(req) {
-           return await signOut(req);
+           return await kvOAuth.signOut(req);
          },
        },
        {
          path: "/protected",
          async handler(req) {
-           return await getSessionId(req) === undefined
+           return await kvOAuth.getSessionId(req) === undefined
              ? new Response("Unauthorized", { status: 401 })
              : new Response("You are allowed");
          },

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -6,7 +6,11 @@ import { handleCallback } from "./handle_callback.ts";
 import { signIn, type SignInOptions } from "./sign_in.ts";
 import { signOut } from "./sign_out.ts";
 
-/** Options for {@linkcode createHelpers}. */
+/**
+ * Options for {@linkcode createHelpers}.
+ *
+ * @deprecated Use {@linkcode KvOAuth} instead. This will be removed in v0.12.0.
+ */
 export interface CreateHelpersOptions {
   /**
    * Options for overwriting the default cookie options throughout each of the
@@ -60,6 +64,8 @@ export interface CreateHelpersOptions {
  *
  * Deno.serve(handler);
  * ```
+ *
+ * @deprecated Use {@linkcode KvOAuth} instead. This will be removed in v0.12.0.
  */
 export function createHelpers(
   oauthConfig: OAuth2ClientConfig,

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -2,7 +2,11 @@
 import { getSessionIdCookie } from "./_http.ts";
 import { isSiteSession } from "./_kv.ts";
 
-/** Options for {@linkcode getSessionId}. */
+/**
+ * Options for {@linkcode getSessionId}.
+ *
+ * @deprecated Use {@linkcode KvOAuth.getSessionId} instead. This will be removed in v0.12.0.
+ */
 export interface GetSessionIdOptions {
   /**
    * The name of the cookie in the request. This must match the cookie name
@@ -27,6 +31,8 @@ export interface GetSessionIdOptions {
  *   return Response.json({ sessionId, hasSessionIdCookie });
  * }
  * ```
+ *
+ * @deprecated Use {@linkcode KvOAuth.getSessionId} instead. This will be removed in v0.12.0.
  */
 export async function getSessionId(
   request: Request,

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -18,7 +18,11 @@ import {
 } from "./_http.ts";
 import { getAndDeleteOAuthSession, setSiteSession } from "./_kv.ts";
 
-/** Options for {@linkcode handleCallback}. */
+/**
+ * Options for {@linkcode handleCallback}.
+ *
+ * @deprecated Use {@linkcode KvOAuth.handleCallback} instead. This will be removed in v0.12.0.
+ */
 export interface HandleCallbackOptions {
   /** Overwrites cookie properties set in the response. These must match the
    * cookie properties used in {@linkcode getSessionId} and
@@ -49,6 +53,8 @@ export interface HandleCallbackOptions {
  *    return response;
  * }
  * ```
+ *
+ * @deprecated Use {@linkcode KvOAuth.handleCallback} instead. This will be removed in v0.12.0.
  */
 export async function handleCallback(
   request: Request,

--- a/lib/kv_oauth.ts
+++ b/lib/kv_oauth.ts
@@ -1,0 +1,274 @@
+// Copyright 2023-2024 the Deno authors. All rights reserved. MIT license.
+
+import {
+  Cookie,
+  deleteCookie,
+  getCookies,
+  OAuth2Client,
+  type OAuth2ClientConfig,
+  SECOND,
+  setCookie,
+  Tokens,
+} from "../deps.ts";
+import {
+  COOKIE_BASE,
+  getCookieName,
+  getSessionIdCookie,
+  getSuccessUrl,
+  isHttps,
+  OAUTH_COOKIE_NAME,
+  redirect,
+  SITE_COOKIE_NAME,
+} from "./_http.ts";
+import {
+  deleteSiteSession,
+  getAndDeleteOAuthSession,
+  isSiteSession,
+  setOAuthSession,
+  setSiteSession,
+} from "./_kv.ts";
+
+/** Options for {@linkcode createKvOAuth}. */
+export interface KvOAuthOptions {
+  /**
+   * Session cookie options used in {@linkcode KvOAuth.handleCallback},
+   * {@linkcode KvOAuth.getSessionId}, and {@linkcode KvOAuth.signOut}.
+   */
+  cookieOptions?: Partial<Cookie>;
+}
+
+/**
+ * A class instance that handles the sign-in, sign-out, callback, and session
+ * management for OAuth 2.0 using {@link https://deno.com/kv | Deno KV }.
+ *
+ * @example
+ * ```ts
+ * import { KvOAuth, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+ *
+ * const oauthConfig = createGitHubOAuthConfig();
+ * const kvOAuth = new KvOAuth(oauthConfig);
+ *
+ * async function handler(request: Request) {
+ *   const { pathname } = new URL(request.url);
+ *   switch (pathname) {
+ *     case "/oauth/sign-in":
+ *       return await kvOAuth.signIn(request);
+ *     case "/oauth/callback":
+ *       const { response } = await kvOAuth.handleCallback(request);
+ *       return response;
+ *     case "/oauth/sign-out":
+ *       return await kvOAuth.signOut(request);
+ *     case "/protected-route":
+ *       return await kvOAuth.getSessionId(request) === undefined
+ *         ? new Response("Unauthorized", { status: 401 })
+ *         : new Response("Authorized");
+ *     default:
+ *       return new Response("Not Found", { status: 404 });
+ *   }
+ * }
+ *
+ * Deno.serve(handler);
+ * ```
+ */
+export class KvOAuth {
+  #oauthClient: OAuth2Client;
+  #options: KvOAuthOptions;
+
+  /** Constructs a new instance. */
+  constructor(oauthConfig: OAuth2ClientConfig, options?: KvOAuthOptions) {
+    this.#oauthClient = new OAuth2Client(oauthConfig);
+    this.#options = options ?? {};
+  }
+
+  /**
+   * Handles the sign-in request and process for the given OAuth configuration
+   * and redirects the client to the authorization URL.
+   *
+   * @see {@link https://deno.land/x/deno_kv_oauth#redirects-after-sign-in-and-sign-out}
+   *
+   * @example
+   * ```ts
+   * import { KvOAuth, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   *
+   * const oauthConfig = createGitHubOAuthConfig();
+   * const kvOAuth = new KvOAuth(oauthConfig);
+   *
+   * async function handleSignIn(request: Request) {
+   *   return await kvOAuth.signIn(request);
+   * }
+   *
+   * Deno.serve(handleSignIn);
+   * ```
+   */
+  async signIn(request: Request, options?: {
+    /** URL parameters that are appended to the authorization URI, if defined. */
+    urlParams?: Record<string, string>;
+  }): Promise<Response> {
+    const state = crypto.randomUUID();
+    const { uri, codeVerifier } = await this.#oauthClient.code
+      .getAuthorizationUri({ state });
+
+    if (options?.urlParams) {
+      Object.entries(options.urlParams).forEach(([key, value]) =>
+        uri.searchParams.append(key, value)
+      );
+    }
+
+    const oauthSessionId = crypto.randomUUID();
+    const cookie: Cookie = {
+      ...COOKIE_BASE,
+      name: getCookieName(OAUTH_COOKIE_NAME, isHttps(request.url)),
+      value: oauthSessionId,
+      secure: isHttps(request.url),
+      /**
+       * A maximum authorization code lifetime of 10 minutes is recommended.
+       * This cookie lifetime matches that value.
+       *
+       * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2}
+       */
+      maxAge: 10 * 60,
+    };
+    const successUrl = getSuccessUrl(request);
+    await setOAuthSession(oauthSessionId, { state, codeVerifier, successUrl }, {
+      expireIn: cookie.maxAge! * SECOND,
+    });
+    const response = redirect(uri.toString());
+    setCookie(response.headers, cookie);
+    return response;
+  }
+
+  /**
+   * Handles the OAuth callback request for the given OAuth configuration, and
+   * then redirects the client to the success URL set in {@linkcode signIn}. The
+   * request URL must match the redirect URL of the OAuth application.
+   *
+   * @example
+   * ```ts
+   * import { KvOAuth, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   *
+   * const oauthConfig = createGitHubOAuthConfig();
+   * const kvOAuth = new KvOAuth(oauthConfig);
+   *
+   * async function handleCallback(request: Request) {
+   *   const { response, tokens, sessionId } = await kvOAuth.handleCallback(request);
+   *
+   *   // Perform some actions with the `tokens` and `sessionId`.
+   *
+   *   return response;
+   * }
+   *
+   * Deno.serve(handleCallback);
+   * ```
+   */
+  async handleCallback(request: Request): Promise<{
+    response: Response;
+    sessionId: string;
+    tokens: Tokens;
+  }> {
+    const oauthCookieName = getCookieName(
+      OAUTH_COOKIE_NAME,
+      isHttps(request.url),
+    );
+    const oauthSessionId = getCookies(request.headers)[oauthCookieName];
+    if (oauthSessionId === undefined) throw new Error("OAuth cookie not found");
+    const oauthSession = await getAndDeleteOAuthSession(oauthSessionId);
+
+    const tokens = await this.#oauthClient.code.getToken(
+      request.url,
+      oauthSession,
+    );
+
+    const sessionId = crypto.randomUUID();
+    const response = redirect(oauthSession.successUrl);
+    const cookie: Cookie = {
+      ...COOKIE_BASE,
+      name: getCookieName(SITE_COOKIE_NAME, isHttps(request.url)),
+      value: sessionId,
+      secure: isHttps(request.url),
+      ...this.#options?.cookieOptions,
+    };
+    setCookie(response.headers, cookie);
+    await setSiteSession(
+      sessionId,
+      cookie.maxAge ? cookie.maxAge * SECOND : undefined,
+    );
+
+    return {
+      response,
+      sessionId,
+      tokens,
+    };
+  }
+
+  /**
+   * Gets the session ID from the cookie header of a request. This can be used to
+   * check whether the client is signed-in and whether the session ID was created
+   * on the server by checking if the return value is defined.
+   *
+   * @example
+   * ```ts
+   * import { KvOAuth, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   *
+   * const oauthConfig = createGitHubOAuthConfig();
+   * const kvOAuth = new KvOAuth(oauthConfig);
+   *
+   * async function handler(request: Request) {
+   *   const sessionId = await kvOAuth.getSessionId(request);
+   *   const hasSessionIdCookie = sessionId !== undefined;
+   *
+   *   return Response.json({ sessionId, hasSessionIdCookie });
+   * }
+   *
+   * Deno.serve(handler);
+   * ```
+   */
+  async getSessionId(request: Request): Promise<string | undefined> {
+    const sessionId = getSessionIdCookie(
+      request,
+      this.#options?.cookieOptions?.name,
+    );
+    return (sessionId !== undefined && await isSiteSession(sessionId))
+      ? sessionId
+      : undefined;
+  }
+
+  /**
+   * Handles the sign-out process, and then redirects the client to the given
+   * success URL.
+   *
+   * @see {@link https://deno.land/x/deno_kv_oauth#redirects-after-sign-in-and-sign-out}
+   *
+   * @example
+   * ```ts
+   * import { KvOAuth, createGitHubOAuthConfig } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   *
+   * const oauthConfig = createGitHubOAuthConfig();
+   * const kvOAuth = new KvOAuth(oauthConfig);
+   *
+   * async function handleSignOut(request: Request) {
+   *   return await kvOAuth.signOut(request);
+   * }
+   *
+   * Deno.serve(handleSignOut);
+   * ```
+   */
+  async signOut(request: Request): Promise<Response> {
+    const successUrl = getSuccessUrl(request);
+    const response = redirect(successUrl);
+
+    const sessionId = getSessionIdCookie(
+      request,
+      this.#options?.cookieOptions?.name,
+    );
+    if (sessionId === undefined) return response;
+    await deleteSiteSession(sessionId);
+
+    const cookieName = this.#options?.cookieOptions?.name ??
+      getCookieName(SITE_COOKIE_NAME, isHttps(request.url));
+    deleteCookie(response.headers, cookieName, {
+      path: COOKIE_BASE.path,
+      ...this.#options?.cookieOptions,
+    });
+    return response;
+  }
+}

--- a/lib/kv_oauth_test.ts
+++ b/lib/kv_oauth_test.ts
@@ -1,0 +1,275 @@
+// Copyright 2023-2024 the Deno authors. All rights reserved. MIT license.
+
+import { KvOAuth } from "./kv_oauth.ts";
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+} from "std/assert/mod.ts";
+import {
+  assertRedirect,
+  randomOAuthConfig,
+  randomOAuthSession,
+  randomTokensBody,
+} from "./_test_utils.ts";
+import { OAUTH_COOKIE_NAME, SITE_COOKIE_NAME } from "./_http.ts";
+import { type Cookie, getSetCookies } from "../deps.ts";
+import {
+  getAndDeleteOAuthSession,
+  setOAuthSession,
+  setSiteSession,
+} from "./_kv.ts";
+import { returnsNext, stub } from "std/testing/mock.ts";
+
+Deno.test("KvOAuth.signIn() returns a response that signs-in the user", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const request = new Request("http://example.com/signin");
+  const response = await kvOAuth.signIn(request);
+  assertRedirect(response);
+
+  const [setCookie] = getSetCookies(response.headers);
+  assert(setCookie !== undefined);
+  assertEquals(setCookie.name, OAUTH_COOKIE_NAME);
+  assertEquals(setCookie.httpOnly, true);
+  assertEquals(setCookie.maxAge, 10 * 60);
+  assertEquals(setCookie.sameSite, "Lax");
+  assertEquals(setCookie.path, "/");
+
+  const oauthSessionId = setCookie.value;
+  const oauthSession = await getAndDeleteOAuthSession(oauthSessionId);
+  assertNotEquals(oauthSession, null);
+  const location = response.headers.get("location")!;
+  const state = new URL(location).searchParams.get("state");
+  assertEquals(oauthSession!.state, state);
+});
+
+Deno.test("KvOAuth.signIn() returns a redirect response with URL params", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const request = new Request("http://example.com/signin");
+  const response = await kvOAuth.signIn(request, { urlParams: { foo: "bar" } });
+  assertRedirect(response);
+  const location = response.headers.get("location")!;
+  assertEquals(new URL(location).searchParams.get("foo"), "bar");
+});
+
+Deno.test("KvOAuth.handleCallback() rejects for no OAuth cookie", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const request = new Request("http://example.com");
+  await assertRejects(
+    async () => await kvOAuth.handleCallback(request),
+    Error,
+    "OAuth cookie not found",
+  );
+});
+
+Deno.test("KvOAuth.handleCallback() rejects for non-existent OAuth session", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const request = new Request("http://example.com", {
+    headers: { cookie: `${OAUTH_COOKIE_NAME}=xxx` },
+  });
+  await assertRejects(
+    async () => await kvOAuth.handleCallback(request),
+    Deno.errors.NotFound,
+    "OAuth session not found",
+  );
+});
+
+Deno.test("KvOAuth.handleCallback() deletes the OAuth session KV entry", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const oauthSessionId = crypto.randomUUID();
+  const oauthSession = randomOAuthSession();
+  await setOAuthSession(oauthSessionId, oauthSession, { expireIn: 1_000 });
+  const request = new Request("http://example.com", {
+    headers: { cookie: `${OAUTH_COOKIE_NAME}=${oauthSessionId}` },
+  });
+  /**
+   * @todo Define the expected error type and message
+   */
+  await assertRejects(() => kvOAuth.handleCallback(request));
+  await assertRejects(
+    async () => await getAndDeleteOAuthSession(oauthSessionId),
+    Deno.errors.NotFound,
+    "OAuth session not found",
+  );
+});
+
+Deno.test("KvOAuth.handleCallback() correctly handles the callback response", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const tokensBody = randomTokensBody();
+  const fetchStub = stub(
+    window,
+    "fetch",
+    returnsNext([Promise.resolve(Response.json(tokensBody))]),
+  );
+  const oauthSessionId = crypto.randomUUID();
+  const oauthSession = randomOAuthSession();
+  await setOAuthSession(oauthSessionId, oauthSession, { expireIn: 1_000 });
+  const searchParams = new URLSearchParams({
+    "response_type": "code",
+    "client_id": "clientId",
+    "code_challenge_method": "S256",
+    code: "code",
+    state: oauthSession.state,
+  });
+  const request = new Request(`http://example.com/callback?${searchParams}`, {
+    headers: { cookie: `${OAUTH_COOKIE_NAME}=${oauthSessionId}` },
+  });
+  const { response, tokens, sessionId } = await kvOAuth.handleCallback(request);
+  fetchStub.restore();
+
+  assertRedirect(response, oauthSession.successUrl);
+  assertEquals(
+    response.headers.get("set-cookie"),
+    `site-session=${sessionId}; HttpOnly; Max-Age=7776000; SameSite=Lax; Path=/`,
+  );
+  assertEquals(tokens.accessToken, tokensBody.access_token);
+  assertEquals(typeof sessionId, "string");
+  await assertRejects(
+    async () => await getAndDeleteOAuthSession(oauthSessionId),
+    Deno.errors.NotFound,
+    "OAuth session not found",
+  );
+});
+
+Deno.test("KvOAuth.handleCallback() correctly handles the callback response with options", async () => {
+  const cookieOptions: Partial<Cookie> = {
+    name: "triple-choc",
+    maxAge: 420,
+    domain: "example.com",
+  };
+  const kvOAuth = new KvOAuth(randomOAuthConfig(), { cookieOptions });
+
+  const tokensBody = randomTokensBody();
+  const fetchStub = stub(
+    window,
+    "fetch",
+    returnsNext([Promise.resolve(Response.json(tokensBody))]),
+  );
+  const oauthSessionId = crypto.randomUUID();
+  const oauthSession = randomOAuthSession();
+  await setOAuthSession(oauthSessionId, oauthSession, { expireIn: 1_000 });
+  const searchParams = new URLSearchParams({
+    "response_type": "code",
+    "client_id": "clientId",
+    "code_challenge_method": "S256",
+    code: "code",
+    state: oauthSession.state,
+  });
+  const request = new Request(`http://example.com/callback?${searchParams}`, {
+    headers: { cookie: `${OAUTH_COOKIE_NAME}=${oauthSessionId}` },
+  });
+
+  const { response, tokens, sessionId } = await kvOAuth.handleCallback(request);
+  fetchStub.restore();
+
+  assertRedirect(response, oauthSession.successUrl);
+  assertEquals(
+    response.headers.get("set-cookie"),
+    `${cookieOptions.name}=${sessionId}; HttpOnly; Max-Age=${cookieOptions.maxAge}; Domain=${cookieOptions.domain}; SameSite=Lax; Path=/`,
+  );
+  assertEquals(tokens.accessToken, tokensBody.access_token);
+  assertEquals(typeof sessionId, "string");
+  await assertRejects(
+    async () => await getAndDeleteOAuthSession(oauthSessionId),
+    Deno.errors.NotFound,
+    "OAuth session not found",
+  );
+});
+
+Deno.test("KvOAuth.getSessionId() returns undefined when cookie is not defined", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+  const request = new Request("http://example.com");
+
+  assertEquals(await kvOAuth.getSessionId(request), undefined);
+});
+
+Deno.test("KvOAuth.getSessionId() returns valid session ID", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const sessionId = crypto.randomUUID();
+  await setSiteSession(sessionId);
+  const request = new Request("http://example.com", {
+    headers: {
+      cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
+    },
+  });
+
+  assertEquals(await kvOAuth.getSessionId(request), sessionId);
+});
+
+Deno.test("KvOAuth.getSessionId() returns valid session ID when cookie name is defined", async () => {
+  const cookieName = "triple-choc";
+  const kvOAuth = new KvOAuth(randomOAuthConfig(), {
+    cookieOptions: { name: cookieName },
+  });
+
+  const sessionId = crypto.randomUUID();
+  await setSiteSession(sessionId);
+
+  const request = new Request("http://example.com", {
+    headers: {
+      cookie: `${cookieName}=${sessionId}`,
+    },
+  });
+
+  assertEquals(await kvOAuth.getSessionId(request), sessionId);
+});
+
+Deno.test("KvOAuth.signOut() returns a redirect response if the user is not signed-in", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const request = new Request("http://example.com/signout");
+  const response = await kvOAuth.signOut(request);
+
+  assertRedirect(response, "/");
+});
+
+Deno.test("KvOAuth.signOut() returns a response that signs out the signed-in user", async () => {
+  const kvOAuth = new KvOAuth(randomOAuthConfig());
+
+  const sessionId = crypto.randomUUID();
+  await setSiteSession(sessionId);
+  const request = new Request("http://example.com/signout", {
+    headers: {
+      cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
+    },
+  });
+  const response = await kvOAuth.signOut(request);
+
+  assertRedirect(response, "/");
+  assertEquals(
+    response.headers.get("set-cookie"),
+    `${SITE_COOKIE_NAME}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+  );
+});
+
+Deno.test("KvOAuth.signOut() returns a response that signs out the signed-in user with cookie options", async () => {
+  const cookieOptions = {
+    name: "triple-choc",
+    domain: "example.com",
+    path: "/path",
+  };
+  const kvOAuth = new KvOAuth(randomOAuthConfig(), { cookieOptions });
+
+  const sessionId = crypto.randomUUID();
+  await setSiteSession(sessionId);
+  const request = new Request("http://example.com/signout", {
+    headers: {
+      cookie: `${cookieOptions.name}=${sessionId}`,
+    },
+  });
+  const response = await kvOAuth.signOut(request);
+
+  assertRedirect(response, "/");
+  assertEquals(
+    response.headers.get("set-cookie"),
+    `${cookieOptions.name}=; Domain=${cookieOptions.domain}; Path=${cookieOptions.path}; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+  );
+});

--- a/lib/sign_in.ts
+++ b/lib/sign_in.ts
@@ -16,7 +16,11 @@ import {
 } from "./_http.ts";
 import { setOAuthSession } from "./_kv.ts";
 
-/** Options for {@linkcode signIn}. */
+/**
+ * Options for {@linkcode signIn}.
+ *
+ * @deprecated Use {@linkcode KvOAuth.signIn} instead. This will be removed in v0.12.0.
+ */
 export interface SignInOptions {
   /** URL parameters that are appended to the authorization URI, if defined. */
   urlParams?: Record<string, string>;
@@ -38,6 +42,8 @@ export interface SignInOptions {
  *  return await signIn(request, oauthConfig);
  * }
  * ```
+ *
+ * @deprecated Use {@linkcode KvOAuth.signIn} instead. This will be removed in v0.12.0.
  */
 export async function signIn(
   request: Request,

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -11,7 +11,11 @@ import {
 } from "./_http.ts";
 import { deleteSiteSession } from "./_kv.ts";
 
-/** Options for {@linkcode signOut}. */
+/**
+ * Options for {@linkcode signOut}.
+ *
+ * @deprecated Use {@linkcode KvOAuth.signOut} instead. This will be removed in v0.12.0.
+ */
 export interface SignOutOptions {
   /**
    * Overwrites cookie properties set in the response. These must match the
@@ -35,6 +39,8 @@ export interface SignOutOptions {
  *   return await signOut(request);
  * }
  * ```
+ *
+ * @deprecated Use {@linkcode KvOAuth.signOut} instead. This will be removed in v0.12.0.
  */
 export async function signOut(
   request: Request,

--- a/mod.ts
+++ b/mod.ts
@@ -20,4 +20,5 @@ export * from "./lib/create_spotify_oauth_config.ts";
 export * from "./lib/create_twitter_oauth_config.ts";
 export * from "./lib/create_helpers.ts";
 export * from "./lib/get_required_env.ts";
+export * from "./lib/kv_oauth.ts";
 export * from "./lib/types.ts";


### PR DESCRIPTION
Previously, there were two ways to use this module, each with its issues:
1. Using helpers. I.e. `signIn()`, `handleCallback()`, `getSessionId()` and `signOut()`. The various helpers made it possible to misuse the module. E.g. using cookie options in one helper but forgetting to use them in another would lead to unexpected behaviour and might be difficult to troubleshoot.
2. Using `createHelpers()` to create the helpers with consistent behaviour, such as cookie settings. It aimed to be a pure function and used the helpers under the hood. The logic of the function is difficult to read immediately, and so is the documentation, specifically [the type signature](https://deno.land/x/deno_kv_oauth@v0.10.0/mod.ts?s=createHelpers).

This PR introduces the `KvOAuth` class. It combines the helpers into a single class, letting the module ensure consistent behaviour across the board. It is also easier to understand from a holistic point of view and is easy to document.

This will be the only way to use this module going forward. The individual helpers and `createHelpers()` are deprecated in this version for removal in v0.12.0.