### PR TITLE
feat: `Helpers` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,24 @@ configurations.
    // server.ts
    import {
      createGitHubOAuthConfig,
-     getSessionId,
-     handleCallback,
-     signIn,
-     signOut,
+     createHelpers,
    } from "https://deno.land/x/deno_kv_oauth/mod.ts";
 
    const oauthConfig = createGitHubOAuthConfig();
+   const {
+     signIn,
+     handleCallback,
+     getSessionId,
+     signOut,
+   } = createHelpers(oauthConfig);
 
    async function handler(request: Request) {
      const { pathname } = new URL(request.url);
      switch (pathname) {
        case "/oauth/signin":
-         return await signIn(request, oauthConfig);
+         return await signIn(request);
        case "/oauth/callback":
-         const { response } = await handleCallback(request, oauthConfig);
+         const { response } = await handleCallback(request);
          return response;
        case "/oauth/signout":
          return await signOut(request);
@@ -109,12 +112,9 @@ configurations.
    ```ts
    // server.ts
    import {
+     createHelpers,
      getRequiredEnv,
-     getSessionId,
-     handleCallback,
      type OAuth2ClientConfig,
-     signIn,
-     signOut,
    } from "https://deno.land/x/deno_kv_oauth/mod.ts";
 
    const oauthConfig: OAuth2ClientConfig = {
@@ -124,14 +124,20 @@ configurations.
      tokenUri: "https://custom.com/oauth/token",
      redirectUri: "https://my-site.com/another-dir/callback",
    };
+   const {
+     signIn,
+     handleCallback,
+     getSessionId,
+     signOut,
+   } = createHelpers(oauthConfig);
 
    async function handler(request: Request) {
      const { pathname } = new URL(request.url);
      switch (pathname) {
        case "/oauth/signin":
-         return await signIn(request, oauthConfig);
+         return await signIn(request);
        case "/another-dir/callback":
-         const { response } = await handleCallback(request, oauthConfig);
+         const { response } = await handleCallback(request);
          return response;
        case "/oauth/signout":
          return await signOut(request);

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -29,8 +29,9 @@ export interface Helpers {
   signIn(request: Request, options?: SignInOptions): Promise<Response>;
   /**
    * Handles the OAuth callback request for the given OAuth configuration, and
-   * then redirects the client to the success URL set in {@linkcode signIn}. The
-   * request URL must match the redirect URL of the OAuth application.
+   * then redirects the client to the success URL set in
+   * {@linkcode Handlers.signIn}. The request URL must match the redirect URL
+   * of the OAuth application.
    *
    * @example
    * ```ts

--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -6,6 +6,88 @@ import { handleCallback } from "./handle_callback.ts";
 import { signIn, type SignInOptions } from "./sign_in.ts";
 import { signOut } from "./sign_out.ts";
 
+export type { SignInOptions };
+
+/** High-level OAuth 2.0 functions */
+export interface Helpers {
+  /**
+   * Handles the sign-in request and process for the given OAuth configuration
+   * and redirects the client to the authorization URL.
+   *
+   * @see {@link https://deno.land/x/deno_kv_oauth#redirects-after-sign-in-and-sign-out}
+   *
+   * @example
+   * ```ts
+   * import { createGitHubOAuthConfig, createHelpers } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   *
+   * const oauthConfig = createGitHubOAuthConfig();
+   * const { signIn } = createHelpers(oauthConfig);
+   *
+   * Deno.serve(async (request) => await signIn(request));
+   * ```
+   */
+  signIn(request: Request, options?: SignInOptions): Promise<Response>;
+  /**
+   * Handles the OAuth callback request for the given OAuth configuration, and
+   * then redirects the client to the success URL set in {@linkcode signIn}. The
+   * request URL must match the redirect URL of the OAuth application.
+   *
+   * @example
+   * ```ts
+   * import { createGitHubOAuthConfig, createHelpers } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   *
+   * const oauthConfig = createGitHubOAuthConfig();
+   * const { handleCallback } = createHelpers(oauthConfig);
+   *
+   * Deno.serve(async (request) => {
+   *   const { response } = await handleCallback(request);
+   *   return response;
+   * });
+   * ```
+   */
+  handleCallback(request: Request): Promise<{
+    response: Response;
+    sessionId: string;
+    tokens: Tokens;
+  }>;
+  /**
+   * Handles the sign-out process, and then redirects the client to the given
+   * success URL.
+   *
+   * @see {@link https://deno.land/x/deno_kv_oauth#redirects-after-sign-in-and-sign-out}
+   *
+   * @example
+   * ```ts
+   * import { createGitHubOAuthConfig, createHelpers } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   *
+   * const oauthConfig = createGitHubOAuthConfig();
+   * const { signOut } = createHelpers(oauthConfig);
+   *
+   * Deno.serve(async (request) => await signOut(request));
+   * ```
+   */
+  signOut(request: Request): Promise<Response>;
+  /**
+   * Gets the session ID from the cookie header of a request. This can be used to
+   * check whether the client is signed-in and whether the session ID was created
+   * on the server by checking if the return value is defined.
+   *
+   * @example
+   * ```ts
+   * import { createGitHubOAuthConfig, createHelpers } from "https://deno.land/x/deno_kv_oauth/mod.ts";
+   *
+   * const oauthConfig = createGitHubOAuthConfig();
+   * const { getSessionId } = createHelpers(oauthConfig);
+   *
+   * Deno.serve(async (request) => {
+   *   const sessionId = await getSessionId(request);
+   *   return Response.json({ sessionId });
+   * });
+   * ```
+   */
+  getSessionId(request: Request): Promise<string | undefined>;
+}
+
 /** Options for {@linkcode createHelpers}. */
 export interface CreateHelpersOptions {
   /**
@@ -64,16 +146,7 @@ export interface CreateHelpersOptions {
 export function createHelpers(
   oauthConfig: OAuth2ClientConfig,
   options?: CreateHelpersOptions,
-): {
-  signIn(request: Request, options?: SignInOptions): Promise<Response>;
-  handleCallback(request: Request): Promise<{
-    response: Response;
-    sessionId: string;
-    tokens: Tokens;
-  }>;
-  signOut(request: Request): Promise<Response>;
-  getSessionId(request: Request): Promise<string | undefined>;
-} {
+): Helpers {
   return {
     async signIn(request: Request, options?: SignInOptions) {
       return await signIn(request, oauthConfig, options);

--- a/lib/create_helpers_test.ts
+++ b/lib/create_helpers_test.ts
@@ -1,0 +1,261 @@
+// Copyright 2023-2024 the Deno authors. All rights reserved. MIT license.
+import { createHelpers } from "./create_helpers.ts";
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+} from "std/assert/mod.ts";
+import { returnsNext, stub } from "std/testing/mock.ts";
+import {
+  getAndDeleteOAuthSession,
+  setOAuthSession,
+  setSiteSession,
+} from "./_kv.ts";
+import { OAUTH_COOKIE_NAME, SITE_COOKIE_NAME } from "./_http.ts";
+import {
+  assertRedirect,
+  randomOAuthConfig,
+  randomOAuthSession,
+  randomTokensBody,
+} from "./_test_utils.ts";
+import { type Cookie, getSetCookies } from "../deps.ts";
+
+Deno.test("signIn() returns a response that signs-in the user", async () => {
+  const { signIn } = createHelpers(randomOAuthConfig());
+  const request = new Request("http://example.com/signin");
+  const response = await signIn(request);
+  assertRedirect(response);
+
+  const [setCookie] = getSetCookies(response.headers);
+  assert(setCookie !== undefined);
+  assertEquals(setCookie.name, OAUTH_COOKIE_NAME);
+  assertEquals(setCookie.httpOnly, true);
+  assertEquals(setCookie.maxAge, 10 * 60);
+  assertEquals(setCookie.sameSite, "Lax");
+  assertEquals(setCookie.path, "/");
+
+  const oauthSessionId = setCookie.value;
+  const oauthSession = await getAndDeleteOAuthSession(oauthSessionId);
+  assertNotEquals(oauthSession, null);
+  const location = response.headers.get("location")!;
+  const state = new URL(location).searchParams.get("state");
+  assertEquals(oauthSession!.state, state);
+});
+
+Deno.test("signIn() returns a redirect response with URL params", async () => {
+  const { signIn } = createHelpers(randomOAuthConfig());
+  const request = new Request("http://example.com/signin");
+  const response = await signIn(request, {
+    urlParams: { foo: "bar" },
+  });
+  assertRedirect(response);
+  const location = response.headers.get("location")!;
+  assertEquals(new URL(location).searchParams.get("foo"), "bar");
+});
+
+Deno.test("handleCallback() rejects for no OAuth cookie", async () => {
+  const { handleCallback } = createHelpers(randomOAuthConfig());
+  const request = new Request("http://example.com");
+  await assertRejects(
+    async () => await handleCallback(request),
+    Error,
+    "OAuth cookie not found",
+  );
+});
+
+Deno.test("handleCallback() rejects for non-existent OAuth session", async () => {
+  const { handleCallback } = createHelpers(randomOAuthConfig());
+  const request = new Request("http://example.com", {
+    headers: { cookie: `${OAUTH_COOKIE_NAME}=xxx` },
+  });
+  await assertRejects(
+    async () => await handleCallback(request),
+    Deno.errors.NotFound,
+    "OAuth session not found",
+  );
+});
+
+Deno.test("handleCallback() deletes the OAuth session KV entry", async () => {
+  const { handleCallback } = createHelpers(randomOAuthConfig());
+  const oauthSessionId = crypto.randomUUID();
+  const oauthSession = randomOAuthSession();
+  await setOAuthSession(oauthSessionId, oauthSession, { expireIn: 1_000 });
+  const request = new Request("http://example.com", {
+    headers: { cookie: `${OAUTH_COOKIE_NAME}=${oauthSessionId}` },
+  });
+  await assertRejects(() => handleCallback(request));
+  await assertRejects(
+    async () => await getAndDeleteOAuthSession(oauthSessionId),
+    Deno.errors.NotFound,
+    "OAuth session not found",
+  );
+});
+
+Deno.test("handleCallback() correctly handles the callback response", async () => {
+  const { handleCallback } = createHelpers(randomOAuthConfig());
+  const tokensBody = randomTokensBody();
+  const fetchStub = stub(
+    window,
+    "fetch",
+    returnsNext([Promise.resolve(Response.json(tokensBody))]),
+  );
+  const oauthSessionId = crypto.randomUUID();
+  const oauthSession = randomOAuthSession();
+  await setOAuthSession(oauthSessionId, oauthSession, { expireIn: 1_000 });
+  const searchParams = new URLSearchParams({
+    "response_type": "code",
+    "client_id": "clientId",
+    "code_challenge_method": "S256",
+    code: "code",
+    state: oauthSession.state,
+  });
+  const request = new Request(`http://example.com/callback?${searchParams}`, {
+    headers: { cookie: `${OAUTH_COOKIE_NAME}=${oauthSessionId}` },
+  });
+  const { response, tokens, sessionId } = await handleCallback(request);
+  fetchStub.restore();
+
+  assertRedirect(response, oauthSession.successUrl);
+  assertEquals(
+    response.headers.get("set-cookie"),
+    `site-session=${sessionId}; HttpOnly; Max-Age=7776000; SameSite=Lax; Path=/`,
+  );
+  assertEquals(tokens.accessToken, tokensBody.access_token);
+  assertEquals(typeof sessionId, "string");
+  await assertRejects(
+    async () => await getAndDeleteOAuthSession(oauthSessionId),
+    Deno.errors.NotFound,
+    "OAuth session not found",
+  );
+});
+
+Deno.test("handleCallback() correctly handles the callback response with options", async () => {
+  const tokensBody = randomTokensBody();
+  const fetchStub = stub(
+    window,
+    "fetch",
+    returnsNext([Promise.resolve(Response.json(tokensBody))]),
+  );
+  const oauthSessionId = crypto.randomUUID();
+  const oauthSession = randomOAuthSession();
+  await setOAuthSession(oauthSessionId, oauthSession, { expireIn: 1_000 });
+  const searchParams = new URLSearchParams({
+    "response_type": "code",
+    "client_id": "clientId",
+    "code_challenge_method": "S256",
+    code: "code",
+    state: oauthSession.state,
+  });
+  const request = new Request(`http://example.com/callback?${searchParams}`, {
+    headers: { cookie: `${OAUTH_COOKIE_NAME}=${oauthSessionId}` },
+  });
+  const cookieOptions: Partial<Cookie> = {
+    name: "triple-choc",
+    maxAge: 420,
+    domain: "example.com",
+  };
+  const { handleCallback } = createHelpers(randomOAuthConfig(), {
+    cookieOptions,
+  });
+  const { response, tokens, sessionId } = await handleCallback(request);
+  fetchStub.restore();
+
+  assertRedirect(response, oauthSession.successUrl);
+  assertEquals(
+    response.headers.get("set-cookie"),
+    `${cookieOptions.name}=${sessionId}; HttpOnly; Max-Age=${cookieOptions.maxAge}; Domain=${cookieOptions.domain}; SameSite=Lax; Path=/`,
+  );
+  assertEquals(tokens.accessToken, tokensBody.access_token);
+  assertEquals(typeof sessionId, "string");
+  await assertRejects(
+    async () => await getAndDeleteOAuthSession(oauthSessionId),
+    Deno.errors.NotFound,
+    "OAuth session not found",
+  );
+});
+
+Deno.test("getSessionId() returns undefined when cookie is not defined", async () => {
+  const { getSessionId } = createHelpers(randomOAuthConfig());
+  const request = new Request("http://example.com");
+
+  assertEquals(await getSessionId(request), undefined);
+});
+
+Deno.test("getSessionId() returns valid session ID", async () => {
+  const { getSessionId } = createHelpers(randomOAuthConfig());
+  const sessionId = crypto.randomUUID();
+  await setSiteSession(sessionId);
+  const request = new Request("http://example.com", {
+    headers: {
+      cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
+    },
+  });
+
+  assertEquals(await getSessionId(request), sessionId);
+});
+
+Deno.test("getSessionId() returns valid session ID when cookie name is defined", async () => {
+  const sessionId = crypto.randomUUID();
+  await setSiteSession(sessionId);
+  const name = "triple-choc";
+  const { getSessionId } = createHelpers(randomOAuthConfig(), {
+    cookieOptions: { name },
+  });
+  const request = new Request("http://example.com", {
+    headers: {
+      cookie: `${name}=${sessionId}`,
+    },
+  });
+
+  assertEquals(await getSessionId(request), sessionId);
+});
+
+Deno.test("signOut() returns a redirect response if the user is not signed-in", async () => {
+  const { signOut } = createHelpers(randomOAuthConfig());
+  const request = new Request("http://example.com/signout");
+  const response = await signOut(request);
+
+  assertRedirect(response, "/");
+});
+
+Deno.test("signOut() returns a response that signs out the signed-in user", async () => {
+  const { signOut } = createHelpers(randomOAuthConfig());
+  const sessionId = crypto.randomUUID();
+  await setSiteSession(sessionId);
+  const request = new Request("http://example.com/signout", {
+    headers: {
+      cookie: `${SITE_COOKIE_NAME}=${sessionId}`,
+    },
+  });
+  const response = await signOut(request);
+
+  assertRedirect(response, "/");
+  assertEquals(
+    response.headers.get("set-cookie"),
+    `${SITE_COOKIE_NAME}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+  );
+});
+
+Deno.test("signOut() returns a response that signs out the signed-in user with cookie options", async () => {
+  const cookieOptions = {
+    name: "triple-choc",
+    domain: "example.com",
+    path: "/path",
+  };
+  const { signOut } = createHelpers(randomOAuthConfig(), { cookieOptions });
+  const sessionId = crypto.randomUUID();
+  await setSiteSession(sessionId);
+  const request = new Request("http://example.com/signout", {
+    headers: {
+      cookie: `${cookieOptions.name}=${sessionId}`,
+    },
+  });
+  const response = await signOut(request);
+
+  assertRedirect(response, "/");
+  assertEquals(
+    response.headers.get("set-cookie"),
+    `${cookieOptions.name}=; Domain=${cookieOptions.domain}; Path=${cookieOptions.path}; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+  );
+});

--- a/lib/get_session_id.ts
+++ b/lib/get_session_id.ts
@@ -27,6 +27,8 @@ export interface GetSessionIdOptions {
  *   return Response.json({ sessionId, hasSessionIdCookie });
  * }
  * ```
+ *
+ * @deprecated Use {@linkcode createHelpers} instead. This will be removed in v0.12.0.
  */
 export async function getSessionId(
   request: Request,

--- a/lib/handle_callback.ts
+++ b/lib/handle_callback.ts
@@ -49,6 +49,8 @@ export interface HandleCallbackOptions {
  *    return response;
  * }
  * ```
+ *
+ * @deprecated Use {@linkcode createHelpers} instead. This will be removed in v0.12.0.
  */
 export async function handleCallback(
   request: Request,

--- a/lib/sign_in.ts
+++ b/lib/sign_in.ts
@@ -38,6 +38,8 @@ export interface SignInOptions {
  *  return await signIn(request, oauthConfig);
  * }
  * ```
+ *
+ * @deprecated Use {@linkcode createHelpers} instead. This will be removed in v0.12.0.
  */
 export async function signIn(
   request: Request,

--- a/lib/sign_out.ts
+++ b/lib/sign_out.ts
@@ -35,6 +35,8 @@ export interface SignOutOptions {
  *   return await signOut(request);
  * }
  * ```
+ *
+ * @deprecated Use {@linkcode createHelpers} instead. This will be removed in v0.12.0.
  */
 export async function signOut(
   request: Request,


### PR DESCRIPTION
This change deprecates `signIn()`, `handleCallback()`, `signOut()`, and `getSessionId()` in favour of the functions created from `createHelpers()`. This ensures that the behaviour of helpers is consistent throughout various pages. The `Helper` interface will make the documentation of these functions easier to read.

Supercedes #312