### PR TITLE
export separate getSessionId outside of helpers 

### DIFF
--- a/lib/create_helpers.ts
+++ b/lib/create_helpers.ts
@@ -273,3 +273,13 @@ export function createHelpers(
     },
   };
 }
+
+export async function getSessionId(request: Request, cookieName?: string) {
+  const sessionId = getSessionIdCookie(
+    request,
+    cookieName
+  );
+  return (sessionId !== undefined && await isSiteSession(sessionId))
+    ? sessionId
+    : undefined;
+}


### PR DESCRIPTION
useful when working with multiple oauth providers no matter the provider used

```ts
const sessionID = getSessionId(ctx.req)

```